### PR TITLE
archive_url_for is class method

### DIFF
--- a/vendor/plugins/redmine_mailing_list_integration/lib/redmine_mailing_list_integration/drivers/typical_driver.rb
+++ b/vendor/plugins/redmine_mailing_list_integration/lib/redmine_mailing_list_integration/drivers/typical_driver.rb
@@ -24,7 +24,7 @@ module RedmineMailingListIntegration
       end
 
       def archive_url
-        archive_url_for(@mailing_list, mail_number)
+        self.class.archive_url_for(@mailing_list, mail_number)
       end
 
       module ClassMethods


### PR DESCRIPTION
Fix NoMethodError: undefined method `archive_url_for' for #&lt;RedmineMailingListIntegration::Drivers::FmlDriver:0xb5fa89ac>.
Its reason is it call archive_url_for in the object but the method is class method.
