### PR TITLE
Allow non redmine members from ml

### DIFF
--- a/vendor/plugins/redmine_mailing_list_integration_imap_supplement/lib/redmine_mailing_list_integration_imap_supplement/imap.rb
+++ b/vendor/plugins/redmine_mailing_list_integration_imap_supplement/lib/redmine_mailing_list_integration_imap_supplement/imap.rb
@@ -45,7 +45,7 @@ module RedmineMailingListIntegrationIMAPSupplement
         fetch(storage_name, query, session).each do |data|
           msg = data.attr['RFC822']
           seqno = data.seqno
-          if MailHandler.receive(msg)
+          if MailHandler.receive(msg, :unknown_user => "accept", :no_permission_check => true)
             logger.debug "Message #{seqno} successfully received" if logger && logger.debug?
             session.store(seqno, "+FLAGS", [:Seen])
           else


### PR DESCRIPTION
MLからメールを取り込む際に、当該メールアドレスがRedmineのメンバーでない場合に無視される。
とりあえずanonymousで取り込むようにするパッチ。
