### PR TITLE
Fix email thread

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_mailing_list_integration/redmine_ext/mailer.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_mailing_list_integration/redmine_ext/mailer.rb
@@ -59,12 +59,14 @@ Mailer.class_eval do
 
     def deliver_issue_edit(journal)
       unless journal.originates_from_mail?
-        issue_edit(journal.user, journal).deliver_later
+        issue_edit(journal.issue.author, journal).deliver_later
       end
     end
 
     def deliver_attachments_added(attachments)
-      attachments_added(attachments.first.author, attachments).deliver_later
+      attachment = attachments.first
+      return unless attachment.container_type == 'Issue'
+      attachments_added(attachment.container.author, attachments).deliver_later
     end
   end
 


### PR DESCRIPTION
In Redmine 4.1, Message-ID and References contains user_id that passed to mailer methods.

> Committed the patch. The new Message-ID formats are as follows:
>
> Issue added:
>
>   Message-Id: <redmine.issue-#{issue.id}.#{issue.created_on}.#{user_id}@example.net>
>
> Issue updated:
>
>   Message-Id: <redmine.journal-#{jounal.id}.#{journal.created_on}.#{user_id}@example.net>
>   References: <redmine.issue-#{issue.id}.#{issue.created_on}.#{user_id}@example.net>
https://www.redmine.org/issues/17096

To fix email thread, pass the same user (issue.author) to mailer methods.


____________________________________________________________________

Your contributions to Redmine are welcome!

Please **open an issue on the [official website]** instead of sending pull requests.

Since the development of Redmine is not conducted on GitHub but on the [official website] and core developers are not monitoring the GitHub repo, pull requests might not get reviewed.

For more detail about how to contribute, please see the wiki page [Contribute] on the [official website].

[official website]: https://www.redmine.org/
[Contribute]: https://www.redmine.org/projects/redmine/wiki/Contribute
