### PR TITLE
remove duplicated indexes

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/db/migrate/20110212081154_create_mailing_list_messages.rb
+++ b/plugins/redmine_bugs_ruby_lang/db/migrate/20110212081154_create_mailing_list_messages.rb
@@ -13,8 +13,6 @@ class CreateMailingListMessages < ActiveRecord::Migration[5.2]
     end
 
     add_index :mailing_list_messages, :message_id
-    add_index :mailing_list_messages, :issue_id
-    add_index :mailing_list_messages, :journal_id
     add_index :mailing_list_messages, [:issue_id, :journal_id]
     add_index :mailing_list_messages, [:mailing_list_id, :message_id]
     add_index :mailing_list_messages, [:mailing_list_id, :mail_number]


### PR DESCRIPTION
```t.references :issue``` already adds an index by default

fixes
```
ArgumentError: Index name 'index_mailing_list_messages_on_issue_id' on table 'mailing_list_messages' already exists
```