### PR TITLE
Fix notification emails for users

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_ruby_lang_mailing_list_customization/redmine_ext/mailer.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_ruby_lang_mailing_list_customization/redmine_ext/mailer.rb
@@ -3,13 +3,16 @@ module RubyLangMailingListCustomizationMailer
     m = super(user, issue)
 
     m.header[:from] = issue.author.mail
+    m.header[:subject] = "[#{issue.project.name} #{issue.tracker.name}##{issue.id}] #{issue.subject}"
     m
   end
 
   def issue_edit(user, journal)
+    issue = journal.issue
     m = super(user, journal)
 
     m.header[:from] = journal.user.mail
+    m.header[:subject] = "[#{issue.project.name} #{issue.tracker.name}##{issue.id}] #{issue.subject}"
     m
   end
 


### PR DESCRIPTION
This ensures that notification emails are sent to users after sending to the mailing lists.

Fixes #101.

---

This is an alternative approach to #115.

/cc @ahorek I've added you as a co-author since you've been exploring this.
