### PR TITLE
Skip same-origin request verification to allow external requests be able to call the API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,8 @@ class ApplicationController < ActionController::Base
   before_action :session_expiration, :user_setup, :check_if_login_required, :set_localization, :check_password_change, :check_twofa_activation
   after_action :record_project_usage
 
+  skip_after_action :verify_same_origin_request, if: -> { request.format == 'json' }
+
   rescue_from ::Unauthorized, :with => :deny_access
   rescue_from ::ActionView::MissingTemplate, :with => :missing_template
 


### PR DESCRIPTION
I was building a website (using Github Pages) to display the issues from https://bugs.ruby-lang.org/

But when I try to call the https://bugs.ruby-lang.org/issues.json API from the browser, 
CORS blocks me and I can retrieve any JSON.
