### PR TITLE
Support mailman3 provided by mailmanlist

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_mailing_list_integration/drivers/mailman_driver.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_mailing_list_integration/drivers/mailman_driver.rb
@@ -4,16 +4,38 @@ module RedmineMailingListIntegration
       include TypicalDriver
 
       def likelihood
-        if /\A\d/ =~ @email.header["X-Mailman-Version"].to_s and
-          @email.header["X-ML-Name"].to_s == @mailing_list.identifier
+        if /\A\d/ =~ @email.header["X-Mailman-Version"].to_s && ml_name == @mailing_list.identifier
           EXACTLY_MATCHED
         else
           NOT_MATCHED
         end
       end
 
+      def mail_number
+        if @email.header["X-Mail-Count"].to_s
+          # for mailman2
+          @email.header["X-Mail-Count"].to_s
+        else
+          # for mailman3
+          mail_count = @email.header["Subject"].match(/\[#{ml_name}:(\d+)\].*/)
+          mail_count && mail_count[1]
+        end
+      end
+
+      def ml_name
+        if @email.header["X-ML-Name"].to_s
+          # for mailman2
+          @email.header["X-ML-Name"].to_s
+        else
+          # for mailman3
+          list_id = @email.header["List-Id"].match(/\<(.*)\.ruby\-lang\.org\>/)
+          list_id && list_id[1]
+        end
+      end
+
       def self.imap_query_for_mail_number(mailing_list, number)
-        ['HEADER', 'X-ML-Name', mailing_list.identifier, 'HEADER', 'X-Mail-Count', number.to_i]
+        query = "#{mailing_list.identifier}:#{number}"
+        ['HEADER', ml_name, mailing_list.identifier, 'HEADER', 'Subject', query]
       end
     end
   end


### PR DESCRIPTION
mailman3 provided by http://mailmanlists.net/ don't have any our custom plugins like

* `X-Mail-Count` header by `post_id` for integration of redmine
* `X-ML-Name` header for integration of redmine

I rewrite a detection by other headers.

