### PR TITLE
Change the rule of rewriting From address

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_ruby_lang_mailing_list_customization/redmine_ext/mailer.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_ruby_lang_mailing_list_customization/redmine_ext/mailer.rb
@@ -19,7 +19,12 @@ module RedmineRubyLangMailingListCustomization
       end
 
       def mail(headers={}, &block)
-        from_addr = headers[:to].to_s.include?('ruby-dev') ? "ruby-dev@ml.ruby-lang.org" : "ruby-core@ml.ruby-lang.org"
+        from_addr = headers[:to].to_s
+        case from_addr
+        when "ruby-dev@ruby-lang.org" then from_addr = "ruby-dev@ml.ruby-lang.org"
+        when "ruby-core@ruby-lang.org" then from_addr = "ruby-core@ml.ruby-lang.org"
+        # otherwise, keep it as is (e.g., "noreply@ruby-lang.org")
+        end
         mail_from = Mail::Address.new(from_addr)
         if mail_from.display_name.blank? && mail_from.comments.blank?
           mail_from.display_name = @author&.logged? ? @author.name : Setting.app_title


### PR DESCRIPTION
Try to partially fixes https://github.com/ruby/b.r-l.o/issues/177#issuecomment-1499559515

> 2. Keep using [noreply@ruby-lang.org](mailto:noreply@ruby-lang.org) for transactional emails