### PR TITLE
Harden anonymous guards on the issues and activity indexes

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -20,7 +20,6 @@
 class ActivitiesController < ApplicationController
   menu_item :activity
   before_action :find_optional_project_by_id, :authorize_global
-  before_action :reject_anonymous_activity_filter, :only => :index
   accept_atom_auth :index
 
   def index
@@ -83,17 +82,5 @@ class ActivitiesController < ApplicationController
 
   rescue ActiveRecord::RecordNotFound
     render_404
-  end
-
-  private
-
-  def reject_anonymous_activity_filter
-    return if User.current.logged?
-    render_403 if excessive_activity_params?
-  end
-
-  def excessive_activity_params?
-    params[:from].present? ||
-      params[:user_id].present?
   end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -20,6 +20,7 @@
 class ActivitiesController < ApplicationController
   menu_item :activity
   before_action :find_optional_project_by_id, :authorize_global
+  before_action :reject_anonymous_activity_filter, :only => :index
   accept_atom_auth :index
 
   def index
@@ -82,5 +83,17 @@ class ActivitiesController < ApplicationController
 
   rescue ActiveRecord::RecordNotFound
     render_404
+  end
+
+  private
+
+  def reject_anonymous_activity_filter
+    return if User.current.logged?
+    render_403 if excessive_activity_params?
+  end
+
+  def excessive_activity_params?
+    params[:from].present? ||
+      params[:user_id].present?
   end
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -20,12 +20,6 @@
 class IssuesController < ApplicationController
   default_search_scope :issues
 
-  caches_action :index,
-    :if => -> { !User.current.logged? && !excessive_query_params? },
-    :expires_in => 5.minutes,
-    :cache_path => -> { request.GET.merge(locale: I18n.locale) }
-
-  before_action :reject_anonymous_issue_filter, :only => :index
   before_action :find_issue, :only => [:show, :edit, :update, :issue_tab]
   before_action :find_issues, :only => [:bulk_edit, :bulk_update, :destroy]
   before_action :authorize, :except => [:index, :new, :create]
@@ -494,19 +488,6 @@ class IssuesController < ApplicationController
   end
 
   private
-
-  def reject_anonymous_issue_filter
-    return if User.current.logged?
-    render_403 if excessive_query_params?
-  end
-
-  def excessive_query_params?
-    params[:set_filter].present? ||
-      params[:query_id].present? ||
-      params[:sort].present? ||
-      params[:per_page].to_i > 50 ||
-      params[:page].to_i > 30
-  end
 
   def query_error(exception)
     session.delete(:issue_query)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -503,8 +503,9 @@ class IssuesController < ApplicationController
   def excessive_query_params?
     params[:set_filter].present? ||
       params[:query_id].present? ||
+      params[:sort].present? ||
       params[:per_page].to_i > 50 ||
-      params[:page].to_i > 50
+      params[:page].to_i > 30
   end
 
   def query_error(exception)

--- a/plugins/redmine_bugs_ruby_lang/init.rb
+++ b/plugins/redmine_bugs_ruby_lang/init.rb
@@ -75,6 +75,9 @@ require 'redmine_mailing_list_integration_imap_supplement/imap'
 require "redmine_ruby_lang_mailing_list_customization/hooks"
 require 'redmine_ruby_lang_mailing_list_customization/redmine_ext'
 
+require 'redmine_bugs_ruby_lang/anonymous_filter/issues_controller'
+require 'redmine_bugs_ruby_lang/anonymous_filter/activities_controller'
+
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular 'use_of_mailng_list', 'uses_of_mailing_list'
 end

--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/activities_controller.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/activities_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RedmineBugsRubyLang
+  module AnonymousFilter
+    module ActivitiesControllerPatch
+      private
+
+      def reject_anonymous_activity_filter
+        return if User.current.logged?
+        render_403 if excessive_activity_params?
+      end
+
+      def excessive_activity_params?
+        params[:from].present? ||
+          params[:user_id].present?
+      end
+    end
+  end
+end
+
+ActivitiesController.class_eval do
+  prepend RedmineBugsRubyLang::AnonymousFilter::ActivitiesControllerPatch
+
+  before_action :reject_anonymous_activity_filter, :only => :index
+end

--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/issues_controller.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/issues_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RedmineBugsRubyLang
+  module AnonymousFilter
+    module IssuesControllerPatch
+      private
+
+      def reject_anonymous_issue_filter
+        return if User.current.logged?
+        render_403 if excessive_query_params?
+      end
+
+      def excessive_query_params?
+        params[:set_filter].present? ||
+          params[:query_id].present? ||
+          params[:sort].present? ||
+          params[:per_page].to_i > 50 ||
+          params[:page].to_i > 30
+      end
+    end
+  end
+end
+
+IssuesController.class_eval do
+  prepend RedmineBugsRubyLang::AnonymousFilter::IssuesControllerPatch
+
+  caches_action :index,
+    :if => -> { !User.current.logged? && !excessive_query_params? },
+    :expires_in => 5.minutes,
+    :cache_path => -> { request.GET.merge(locale: I18n.locale) }
+
+  before_action :reject_anonymous_issue_filter, :only => :index
+end


### PR DESCRIPTION
A distributed scraper rotating spoofed browser user agents hammered the issues index (sort/filter permutations, deep pagination) and the activity feed (date/user walks), saturating the Heroku web dynos with H12 request-timeout 503s. The existing guest guard still let plain `?page=N&sort=...` through.

This adds sort and lowers the page threshold to 30 on the issues guard, adds an equivalent guard that rejects anonymous from/user_id on activity, and moves both guards plus the guest action cache into the `redmine_bugs_ruby_lang` plugin to keep the core controllers close to upstream. Default views, type filters, and atom feeds stay open to anonymous users.