### PR TITLE
Match Zeitwerk constant names in anonymous filter patches

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/activities_controller.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/activities_controller.rb
@@ -2,7 +2,7 @@
 
 module RedmineBugsRubyLang
   module AnonymousFilter
-    module ActivitiesControllerPatch
+    module ActivitiesController
       private
 
       def reject_anonymous_activity_filter
@@ -19,7 +19,7 @@ module RedmineBugsRubyLang
 end
 
 ActivitiesController.class_eval do
-  prepend RedmineBugsRubyLang::AnonymousFilter::ActivitiesControllerPatch
+  prepend RedmineBugsRubyLang::AnonymousFilter::ActivitiesController
 
   before_action :reject_anonymous_activity_filter, :only => :index
 end

--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/issues_controller.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/issues_controller.rb
@@ -2,7 +2,7 @@
 
 module RedmineBugsRubyLang
   module AnonymousFilter
-    module IssuesControllerPatch
+    module IssuesController
       private
 
       def reject_anonymous_issue_filter
@@ -22,7 +22,7 @@ module RedmineBugsRubyLang
 end
 
 IssuesController.class_eval do
-  prepend RedmineBugsRubyLang::AnonymousFilter::IssuesControllerPatch
+  prepend RedmineBugsRubyLang::AnonymousFilter::IssuesController
 
   caches_action :index,
     :if => -> { !User.current.logged? && !excessive_query_params? },


### PR DESCRIPTION
Zeitwerk expects issues_controller.rb to define ::IssuesController under the file's namespace, so the Patch suffix broke eager loading on deploy.

