### PR TITLE
Add redmine_mcp plugin exposing an MCP endpoint for AI agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 !/plugins/redmica_s3
 !/plugins/redmineup_tags
 !/plugins/redmine_hearts
+!/plugins/redmine_mcp
 !/plugins/README
 /public/assets/*
 /public/dispatch.*

--- a/plugins/redmine_mcp/README.md
+++ b/plugins/redmine_mcp/README.md
@@ -1,0 +1,54 @@
+# Redmine MCP Server
+
+This plugin adds a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint to Redmine so that AI coding agents (Claude Code, Claude.ai, and other MCP clients) can search, read, create and update issues and read wiki pages.
+
+## Endpoint
+
+```
+POST /mcp
+```
+
+The endpoint implements the Streamable HTTP transport in its stateless form. Every JSON-RPC request is answered with a single `application/json` response. `GET /mcp` returns `405 Method Not Allowed` because the server never opens SSE streams.
+
+## Authentication
+
+Requests are authenticated with the per-user Redmine REST API key. Users can find or generate their key on the "My account" page (`/my/account`, right sidebar). `Administration > Settings > API > Enable REST web service` must be enabled.
+
+The key is accepted in any of the following forms:
+
+- `X-Redmine-API-Key: <key>` header (the standard Redmine way)
+- `Authorization: Bearer <key>` header (for MCP clients that only support bearer tokens)
+- HTTP Basic authentication with the key as the username
+
+Anonymous access is rejected with `401`. Every tool call runs with the permissions of the key owner, so the results are exactly what that user can see and do in the web UI. Private issues, private notes and workflow rules are all enforced by the regular Redmine permission layer.
+
+## Client setup
+
+Claude Code:
+
+```
+claude mcp add --transport http bugs-ruby https://bugs.ruby-lang.org/mcp \
+  --header "X-Redmine-API-Key: YOUR_API_KEY"
+```
+
+Any other MCP client: configure a Streamable HTTP server with URL `https://bugs.ruby-lang.org/mcp` and the header above.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `whoami` | Verify authentication, report text formatting and memberships |
+| `list_projects` | List visible projects and their identifiers |
+| `project_metadata` | Valid trackers, statuses, priorities, categories, versions, assignees and your permissions in a project |
+| `search` | Full-text search over issues (including notes), wiki pages and more |
+| `list_issues` | Structured issue filtering (project, status, tracker, assignee, author, dates) |
+| `get_issue` | One issue in full: description, custom fields, comments, history, relations, attachments |
+| `create_issue` | Create an issue (requires `add_issues` permission) |
+| `update_issue` | Comment on an issue and/or change attributes, with workflow validation |
+| `get_wiki_page` | Read a wiki page or list all page titles |
+
+## Tests
+
+```
+bundle exec rake redmine:plugins:test NAME=redmine_mcp
+```

--- a/plugins/redmine_mcp/app/controllers/mcp_controller.rb
+++ b/plugins/redmine_mcp/app/controllers/mcp_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# MCP (Model Context Protocol) endpoint using the Streamable HTTP transport
+# in its stateless form: every JSON-RPC request is answered with a plain
+# application/json response, no SSE stream and no server-side session.
+#
+# Authentication reuses Redmine's REST API authentication: the per-user API
+# key is accepted via the X-Redmine-API-Key header, HTTP Basic (key as
+# username) or an Authorization: Bearer header.
+class McpController < ApplicationController
+  accept_api_auth :handle
+
+  before_action :require_login, only: :handle
+
+  def handle
+    unless request.media_type == 'application/json'
+      render json: RedmineMcp::JsonRpc.error_response(nil, -32700, 'Content-Type must be application/json'), status: :bad_request
+      return
+    end
+
+    server = RedmineMcp::Server.new
+    payload = server.handle(request.raw_post)
+
+    if payload.nil?
+      # Notification (no id): acknowledge without a body
+      head :accepted
+    else
+      render json: payload
+    end
+  end
+
+  def method_not_allowed
+    response.headers['Allow'] = 'POST'
+    head :method_not_allowed
+  end
+
+  private
+
+  # Also accept "Authorization: Bearer <api key>" so that MCP clients that
+  # can only send a bearer token work out of the box. The token is only
+  # treated as an API key when it actually resolves to a user, so Doorkeeper
+  # OAuth tokens keep working through the regular flow.
+  def api_key_from_request
+    key = super
+    return key if key
+
+    token = request.headers['Authorization'].to_s[/\ABearer (.+)\z/i, 1]
+    token if token && User.find_by_api_key(token)
+  end
+end

--- a/plugins/redmine_mcp/config/routes.rb
+++ b/plugins/redmine_mcp/config/routes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  post 'mcp', to: 'mcp#handle', defaults: {format: 'json'}
+  match 'mcp', to: 'mcp#method_not_allowed', via: [:get, :delete, :put, :patch], defaults: {format: 'json'}
+end

--- a/plugins/redmine_mcp/init.rb
+++ b/plugins/redmine_mcp/init.rb
@@ -4,13 +4,13 @@ require 'redmine'
 
 Redmine::Plugin.register :redmine_mcp do
   name 'Redmine MCP Server'
-  author 'Ruby core team'
+  author 'Hiroshi SHIBATA'
   description 'Exposes a Model Context Protocol (MCP) endpoint at /mcp so that ' \
               'AI coding agents can search, read and update issues on this Redmine ' \
               'using per-user REST API keys.'
   version '1.0.0'
-  url 'https://github.com/ruby/b.r-l.o'
-  author_url 'https://github.com/ruby/b.r-l.o'
+  url 'https://github.com/hsbt/redmine_mcp'
+  author_url 'https://github.com/hsbt/redmine_mcp'
 
   requires_redmine version_or_higher: '5.0'
 end

--- a/plugins/redmine_mcp/init.rb
+++ b/plugins/redmine_mcp/init.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'redmine'
+
+Redmine::Plugin.register :redmine_mcp do
+  name 'Redmine MCP Server'
+  author 'Ruby core team'
+  description 'Exposes a Model Context Protocol (MCP) endpoint at /mcp so that ' \
+              'AI coding agents can search, read and update issues on this Redmine ' \
+              'using per-user REST API keys.'
+  version '1.0.0'
+  url 'https://github.com/ruby/b.r-l.o'
+  author_url 'https://github.com/ruby/b.r-l.o'
+
+  requires_redmine version_or_higher: '5.0'
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/json_rpc.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/json_rpc.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  # Minimal JSON-RPC 2.0 message helpers for the MCP endpoint
+  module JsonRpc
+    PARSE_ERROR      = -32700
+    INVALID_REQUEST  = -32600
+    METHOD_NOT_FOUND = -32601
+    INVALID_PARAMS   = -32602
+    INTERNAL_ERROR   = -32603
+
+    # Protocol-level error that is reported to the client as a JSON-RPC error
+    class Error < StandardError
+      attr_reader :code
+
+      def initialize(code, message)
+        @code = code
+        super(message)
+      end
+    end
+
+    def self.result_response(id, result)
+      {jsonrpc: '2.0', id: id, result: result}
+    end
+
+    def self.error_response(id, code, message)
+      {jsonrpc: '2.0', id: id, error: {code: code, message: message}}
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/server.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/server.rb
@@ -112,7 +112,7 @@ module RedmineMcp
       tool_error('You are not allowed to perform this action')
     rescue StandardError => e
       log_error(e)
-      tool_error("Internal error (#{e.class.name})")
+      tool_error('Internal error')
     end
 
     def tool_result(data)

--- a/plugins/redmine_mcp/lib/redmine_mcp/server.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/server.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  # Stateless MCP server: dispatches JSON-RPC 2.0 messages to tool
+  # implementations. One instance handles one HTTP request.
+  # The authenticated user is taken from User.current, which the controller
+  # sets up through Redmine's regular API authentication.
+  class Server
+    # Newest first. The first entry is offered when the client requests an
+    # unknown version.
+    PROTOCOL_VERSIONS = %w[2025-06-18 2025-03-26 2024-11-05].freeze
+
+    INSTRUCTIONS = <<~TEXT.freeze
+      MCP server for this Redmine instance. All operations run with the
+      permissions of the user who owns the API key, so results are limited to
+      what that user can see and do in the web UI.
+
+      Typical workflow: call `whoami` once to confirm authentication, use
+      `search` or `list_issues` to locate issues, `get_issue` to read a full
+      ticket including comments, and `update_issue`/`create_issue` to write.
+      Call `project_metadata` to discover valid trackers, statuses,
+      priorities, categories, versions and assignees before writing.
+      Issue descriptions and notes use the wiki text formatting reported by
+      `whoami` (field `text_formatting`).
+    TEXT
+
+    def handle(raw_body)
+      message =
+        begin
+          JSON.parse(raw_body.to_s)
+        rescue JSON::ParserError
+          return JsonRpc.error_response(nil, JsonRpc::PARSE_ERROR, 'Parse error')
+        end
+
+      case message
+      when Hash
+        handle_message(message)
+      when Array
+        # JSON-RPC batches were removed from MCP in 2025-06-18 but older
+        # clients may still send them
+        return JsonRpc.error_response(nil, JsonRpc::INVALID_REQUEST, 'Invalid Request') if message.empty?
+
+        responses = message.filter_map {|m| handle_message(m)}
+        responses.empty? ? nil : responses
+      else
+        JsonRpc.error_response(nil, JsonRpc::INVALID_REQUEST, 'Invalid Request')
+      end
+    end
+
+    private
+
+    def handle_message(message)
+      unless message.is_a?(Hash) && message['jsonrpc'] == '2.0' && message['method'].is_a?(String)
+        id = message.is_a?(Hash) ? message['id'] : nil
+        return JsonRpc.error_response(id, JsonRpc::INVALID_REQUEST, 'Invalid Request')
+      end
+
+      id = message['id']
+      params = message['params'].is_a?(Hash) ? message['params'] : {}
+
+      # Notifications (no id) never get a response
+      return nil if id.nil?
+
+      result =
+        case message['method']
+        when 'initialize'
+          initialize_result(params)
+        when 'ping'
+          {}
+        when 'tools/list'
+          {tools: Tools.all.map(&:definition)}
+        when 'tools/call'
+          tools_call(params)
+        else
+          return JsonRpc.error_response(id, JsonRpc::METHOD_NOT_FOUND, "Method not found: #{message['method']}")
+        end
+      JsonRpc.result_response(id, result)
+    rescue JsonRpc::Error => e
+      JsonRpc.error_response(id, e.code, e.message)
+    rescue StandardError => e
+      log_error(e)
+      JsonRpc.error_response(id, JsonRpc::INTERNAL_ERROR, 'Internal error')
+    end
+
+    def initialize_result(params)
+      requested = params['protocolVersion'].to_s
+      version = PROTOCOL_VERSIONS.include?(requested) ? requested : PROTOCOL_VERSIONS.first
+      {
+        protocolVersion: version,
+        capabilities: {tools: {listChanged: false}},
+        serverInfo: {
+          name: 'redmine-mcp',
+          title: Setting.app_title,
+          version: Redmine::Plugin.find(:redmine_mcp).version
+        },
+        instructions: INSTRUCTIONS
+      }
+    end
+
+    def tools_call(params)
+      tool = Tools.find(params['name'].to_s)
+      raise JsonRpc::Error.new(JsonRpc::INVALID_PARAMS, "Unknown tool: #{params['name']}") unless tool
+
+      arguments = params['arguments'].is_a?(Hash) ? params['arguments'] : {}
+      data = tool.new(User.current).call(arguments)
+      tool_result(data)
+    rescue Tools::ToolError => e
+      tool_error(e.message)
+    rescue ActiveRecord::RecordNotFound
+      tool_error('Not found or not visible to you')
+    rescue ::Unauthorized
+      tool_error('You are not allowed to perform this action')
+    rescue StandardError => e
+      log_error(e)
+      tool_error("Internal error (#{e.class.name})")
+    end
+
+    def tool_result(data)
+      text = data.is_a?(String) ? data : JSON.pretty_generate(data)
+      {content: [{type: 'text', text: text}], isError: false}
+    end
+
+    def tool_error(message)
+      {content: [{type: 'text', text: message}], isError: true}
+    end
+
+    def log_error(exception)
+      Rails.logger.error("[redmine_mcp] #{exception.class.name}: #{exception.message}\n  #{exception.backtrace&.first(10)&.join("\n  ")}")
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    # Tool-level failure reported to the MCP client as a tool result with
+    # isError: true, so that the calling model can read the message and
+    # correct its arguments
+    class ToolError < StandardError; end
+
+    def self.all
+      [
+        Whoami,
+        ListProjects,
+        ProjectMetadata,
+        Search,
+        ListIssues,
+        GetIssue,
+        CreateIssue,
+        UpdateIssue,
+        GetWikiPage
+      ]
+    end
+
+    def self.find(name)
+      all.detect {|tool| tool.tool_name == name}
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/base.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/base.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class Base
+      class << self
+        def tool_name(value = nil)
+          @tool_name = value if value
+          @tool_name
+        end
+
+        def description(value = nil)
+          @description = value if value
+          @description
+        end
+
+        def input_schema(value = nil)
+          @input_schema = value if value
+          @input_schema || {type: 'object', properties: {}}
+        end
+
+        def definition
+          {name: tool_name, description: description, inputSchema: input_schema}
+        end
+      end
+
+      attr_reader :user
+
+      def initialize(user)
+        @user = user
+      end
+
+      def call(args)
+        raise NotImplementedError
+      end
+
+      private
+
+      def fail!(message)
+        raise ToolError, message
+      end
+
+      def base_url(path)
+        "#{Setting.protocol}://#{Setting.host_name}#{path}"
+      end
+
+      def find_project!(identifier)
+        fail!('Missing required argument: project') if identifier.blank?
+
+        identifier = identifier.to_s
+        scope = Project.visible(user)
+        project = scope.find_by_identifier(identifier)
+        project ||= scope.find_by_id(identifier.to_i) if /\A\d+\z/.match?(identifier)
+        project || fail!("Project not found or not visible: #{identifier}")
+      end
+
+      def find_issue!(id)
+        fail!('Missing required argument: id') if id.blank?
+
+        Issue.visible(user).find_by_id(id.to_i) ||
+          fail!("Issue ##{id} not found or not visible to you")
+      end
+
+      def pagination(args, default: 25, max: 100)
+        limit = args['limit'].to_i
+        limit = default if limit <= 0
+        limit = max if limit > max
+        offset = [args['offset'].to_i, 0].max
+        [limit, offset]
+      end
+
+      # Accepts a numeric id or a login and returns the matching active
+      # principal (user or group)
+      def resolve_principal!(value)
+        value = value.to_s.strip
+        principal =
+          if /\A\d+\z/.match?(value)
+            Principal.find_by_id(value.to_i)
+          else
+            User.active.find_by_login(value)
+          end
+        principal || fail!("User not found: #{value} (use a numeric id or a login)")
+      end
+
+      def resolve_tracker!(project, value)
+        value = value.to_s.strip
+        trackers = project.trackers
+        tracker =
+          if /\A\d+\z/.match?(value)
+            trackers.find_by_id(value.to_i)
+          else
+            trackers.detect {|t| t.name.casecmp?(value)}
+          end
+        tracker || fail!("Unknown tracker: #{value}. Available: #{trackers.map(&:name).join(', ')}")
+      end
+
+      def resolve_status!(value)
+        value = value.to_s.strip
+        status =
+          if /\A\d+\z/.match?(value)
+            IssueStatus.find_by_id(value.to_i)
+          else
+            IssueStatus.all.detect {|s| s.name.casecmp?(value)}
+          end
+        status || fail!("Unknown status: #{value}. Available: #{IssueStatus.sorted.pluck(:name).join(', ')}")
+      end
+
+      def resolve_priority!(value)
+        value = value.to_s.strip
+        priorities = IssuePriority.active
+        priority =
+          if /\A\d+\z/.match?(value)
+            priorities.find_by_id(value.to_i)
+          else
+            priorities.detect {|p| p.name.casecmp?(value)}
+          end
+        priority || fail!("Unknown priority: #{value}. Available: #{priorities.map(&:name).join(', ')}")
+      end
+
+      def parse_time!(value, field)
+        Time.zone.parse(value.to_s) || fail!("Invalid #{field}: #{value}")
+      rescue ArgumentError
+        fail!("Invalid #{field}: #{value} (use an ISO 8601 date or datetime)")
+      end
+
+      def issue_summary(issue)
+        {
+          id: issue.id,
+          subject: issue.subject,
+          project: issue.project.identifier,
+          tracker: issue.tracker.name,
+          status: issue.status.name,
+          priority: issue.priority&.name,
+          author: issue.author&.name,
+          assigned_to: issue.assigned_to&.name,
+          created_on: issue.created_on&.iso8601,
+          updated_on: issue.updated_on&.iso8601,
+          closed_on: issue.closed_on&.iso8601,
+          url: base_url("/issues/#{issue.id}")
+        }.compact
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/base.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/base.rb
@@ -149,6 +149,17 @@ module RedmineMcp
         fail!("Invalid #{field}: #{value} (use an ISO 8601 date or datetime)")
       end
 
+      # Maps a {field name => value} hash to the {custom_field_id => value}
+      # shape expected by safe_attributes 'custom_field_values'.
+      def custom_field_values!(project, fields)
+        available = project.all_issue_custom_fields
+        fields.each_with_object({}) do |(name, value), values|
+          field = available.detect {|f| f.name.casecmp?(name.to_s.strip)}
+          field || fail!("Unknown custom field: #{name}. Available: #{available.map(&:name).join(', ')}")
+          values[field.id.to_s] = value
+        end
+      end
+
       def issue_summary(issue)
         {
           id: issue.id,

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/base.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/base.rb
@@ -82,9 +82,11 @@ module RedmineMcp
         principal || fail!("User not found: #{value} (use a numeric id or a login)")
       end
 
-      def resolve_tracker!(project, value)
+      # With a project, restricts to that project's trackers; without one
+      # (e.g. a global issue filter) resolves against all trackers.
+      def resolve_tracker!(value, project: nil)
         value = value.to_s.strip
-        trackers = project.trackers
+        trackers = project ? project.trackers : Tracker.sorted
         tracker =
           if /\A\d+\z/.match?(value)
             trackers.find_by_id(value.to_i)
@@ -115,6 +117,30 @@ module RedmineMcp
             priorities.detect {|p| p.name.casecmp?(value)}
           end
         priority || fail!("Unknown priority: #{value}. Available: #{priorities.map(&:name).join(', ')}")
+      end
+
+      def resolve_category!(project, value)
+        value = value.to_s.strip
+        categories = project.issue_categories
+        category =
+          if /\A\d+\z/.match?(value)
+            categories.find_by_id(value.to_i)
+          else
+            categories.detect {|c| c.name.casecmp?(value)}
+          end
+        category || fail!("Unknown category: #{value}. Available: #{categories.map(&:name).join(', ')}")
+      end
+
+      def resolve_version!(project, value)
+        value = value.to_s.strip
+        versions = project.shared_versions
+        version =
+          if /\A\d+\z/.match?(value)
+            versions.find_by_id(value.to_i)
+          else
+            versions.detect {|v| v.name.casecmp?(value)}
+          end
+        version || fail!("Unknown version: #{value}. Available: #{versions.map(&:name).join(', ')}")
       end
 
       def parse_time!(value, field)

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/create_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/create_issue.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class CreateIssue < Base
+      tool_name 'create_issue'
+      description 'Creates a new issue. Requires the add_issues permission in the target project. ' \
+                  'Use project_metadata first to discover valid trackers, priorities, categories, ' \
+                  'versions and assignees. The description uses the wiki text formatting reported by whoami.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            project: {type: 'string', description: 'Project identifier (see list_projects)'},
+            subject: {type: 'string', description: 'Issue subject (one line)'},
+            description: {type: 'string', description: 'Issue description'},
+            tracker: {type: 'string', description: "Tracker name, e.g. 'Bug' or 'Feature'. Default: the project's first tracker"},
+            priority: {type: 'string', description: 'Priority name. Default: the default priority'},
+            assigned_to: {type: 'string', description: 'Assignee login or numeric id'},
+            category: {type: 'string', description: 'Issue category name'},
+            version: {type: 'string', description: 'Target version name'},
+            custom_fields: {
+              type: 'object',
+              description: 'Custom field values keyed by field name, ' \
+                           "e.g. {\"ruby -v\": \"ruby 3.4.0\", \"Backport\": \"3.3: REQUIRED\"}",
+              additionalProperties: {type: 'string'}
+            }
+          },
+          required: %w[project subject]
+        }
+      )
+
+      def call(args)
+        project = find_project!(args['project'])
+        fail!("You are not allowed to create issues in #{project.identifier}") unless user.allowed_to?(:add_issues, project)
+        fail!('Missing required argument: subject') if args['subject'].blank?
+
+        issue = Issue.new(project: project, author: user)
+        issue.send(:safe_attributes=, build_attributes(project, args), user)
+
+        if issue.save
+          {created: true}.merge(issue_summary(issue))
+        else
+          fail!("Issue could not be created: #{issue.errors.full_messages.join(', ')}")
+        end
+      end
+
+      private
+
+      def build_attributes(project, args)
+        attrs = {
+          'subject' => args['subject'].to_s,
+          'description' => args['description'].to_s
+        }
+        attrs['tracker_id'] = resolve_tracker!(project, args['tracker']).id if args['tracker'].present?
+        attrs['priority_id'] = resolve_priority!(args['priority']).id if args['priority'].present?
+        attrs['assigned_to_id'] = resolve_principal!(args['assigned_to']).id if args['assigned_to'].present?
+        if args['category'].present?
+          category = project.issue_categories.detect {|c| c.name.casecmp?(args['category'].to_s.strip)}
+          category || fail!("Unknown category: #{args['category']}. Available: #{project.issue_categories.map(&:name).join(', ')}")
+          attrs['category_id'] = category.id
+        end
+        if args['version'].present?
+          version = project.shared_versions.detect {|v| v.name.casecmp?(args['version'].to_s.strip)}
+          version || fail!("Unknown version: #{args['version']}. Available: #{project.shared_versions.map(&:name).join(', ')}")
+          attrs['fixed_version_id'] = version.id
+        end
+        if args['custom_fields'].is_a?(Hash)
+          attrs['custom_field_values'] = custom_field_values(project, args['custom_fields'])
+        end
+        attrs
+      end
+
+      def custom_field_values(project, fields)
+        available = project.all_issue_custom_fields
+        fields.each_with_object({}) do |(name, value), values|
+          field = available.detect {|f| f.name.casecmp?(name.to_s.strip)}
+          field || fail!("Unknown custom field: #{name}. Available: #{available.map(&:name).join(', ')}")
+          values[field.id.to_s] = value
+        end
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/create_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/create_issue.rb
@@ -58,18 +58,9 @@ module RedmineMcp
         attrs['category_id'] = resolve_category!(project, args['category']).id if args['category'].present?
         attrs['fixed_version_id'] = resolve_version!(project, args['version']).id if args['version'].present?
         if args['custom_fields'].is_a?(Hash)
-          attrs['custom_field_values'] = custom_field_values(project, args['custom_fields'])
+          attrs['custom_field_values'] = custom_field_values!(project, args['custom_fields'])
         end
         attrs
-      end
-
-      def custom_field_values(project, fields)
-        available = project.all_issue_custom_fields
-        fields.each_with_object({}) do |(name, value), values|
-          field = available.detect {|f| f.name.casecmp?(name.to_s.strip)}
-          field || fail!("Unknown custom field: #{name}. Available: #{available.map(&:name).join(', ')}")
-          values[field.id.to_s] = value
-        end
       end
     end
   end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/create_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/create_issue.rb
@@ -52,19 +52,11 @@ module RedmineMcp
           'subject' => args['subject'].to_s,
           'description' => args['description'].to_s
         }
-        attrs['tracker_id'] = resolve_tracker!(project, args['tracker']).id if args['tracker'].present?
+        attrs['tracker_id'] = resolve_tracker!(args['tracker'], project: project).id if args['tracker'].present?
         attrs['priority_id'] = resolve_priority!(args['priority']).id if args['priority'].present?
         attrs['assigned_to_id'] = resolve_principal!(args['assigned_to']).id if args['assigned_to'].present?
-        if args['category'].present?
-          category = project.issue_categories.detect {|c| c.name.casecmp?(args['category'].to_s.strip)}
-          category || fail!("Unknown category: #{args['category']}. Available: #{project.issue_categories.map(&:name).join(', ')}")
-          attrs['category_id'] = category.id
-        end
-        if args['version'].present?
-          version = project.shared_versions.detect {|v| v.name.casecmp?(args['version'].to_s.strip)}
-          version || fail!("Unknown version: #{args['version']}. Available: #{project.shared_versions.map(&:name).join(', ')}")
-          attrs['fixed_version_id'] = version.id
-        end
+        attrs['category_id'] = resolve_category!(project, args['category']).id if args['category'].present?
+        attrs['fixed_version_id'] = resolve_version!(project, args['version']).id if args['version'].present?
         if args['custom_fields'].is_a?(Hash)
           attrs['custom_field_values'] = custom_field_values(project, args['custom_fields'])
         end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/get_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/get_issue.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class GetIssue < Base
+      tool_name 'get_issue'
+      description 'Returns one issue in full: description, custom fields, all comments and ' \
+                  'attribute changes (the discussion thread), related issues, subtasks and attachments.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            id: {type: 'integer', description: 'Issue id (the number in the issue URL)'},
+            include_journals: {
+              type: 'boolean',
+              description: 'Include comments and change history. Default: true. ' \
+                           'Set to false for a shorter response when only the description matters.'
+            }
+          },
+          required: ['id']
+        }
+      )
+
+      DETAIL_VALUE_CLASSES = {
+        'status_id' => proc {|v| IssueStatus.find_by_id(v)&.name},
+        'tracker_id' => proc {|v| Tracker.find_by_id(v)&.name},
+        'priority_id' => proc {|v| IssuePriority.find_by_id(v)&.name},
+        'assigned_to_id' => proc {|v| Principal.find_by_id(v)&.name},
+        'author_id' => proc {|v| Principal.find_by_id(v)&.name},
+        'category_id' => proc {|v| IssueCategory.find_by_id(v)&.name},
+        'fixed_version_id' => proc {|v| Version.find_by_id(v)&.name},
+        'project_id' => proc {|v| Project.find_by_id(v)&.identifier},
+        'parent_id' => proc {|v| "##{v}"}
+      }.freeze
+
+      def call(args)
+        issue = find_issue!(args['id'])
+
+        hash = issue_summary(issue)
+        hash[:description] = issue.description
+        hash[:category] = issue.category&.name
+        hash[:target_version] = issue.fixed_version&.name
+        hash[:is_private] = issue.is_private?
+        hash[:done_ratio] = issue.done_ratio
+        hash[:start_date] = issue.start_date&.iso8601
+        hash[:due_date] = issue.due_date&.iso8601
+        hash[:custom_fields] = issue.visible_custom_field_values(user).map do |value|
+          {name: value.custom_field.name, value: value.value}
+        end
+        hash[:parent] = related_issue_hash(issue.parent) if issue.parent&.visible?(user)
+        hash[:subtasks] = issue.children.visible(user).map {|child| related_issue_hash(child)}
+        hash[:related_issues] = relations(issue)
+        hash[:attachments] = issue.attachments.map {|attachment| attachment_hash(attachment)}
+        hash[:journals] = journals(issue) unless args['include_journals'] == false
+        hash.compact
+      end
+
+      private
+
+      def related_issue_hash(other)
+        {id: other.id, subject: other.subject, status: other.status.name}
+      end
+
+      def relations(issue)
+        issue.relations.filter_map do |relation|
+          other = relation.other_issue(issue)
+          next unless other.visible?(user)
+
+          related_issue_hash(other).merge(relation_type: relation.relation_type_for(issue))
+        end
+      end
+
+      def attachment_hash(attachment)
+        {
+          id: attachment.id,
+          filename: attachment.filename,
+          filesize: attachment.filesize,
+          content_type: attachment.content_type,
+          author: attachment.author&.name,
+          created_on: attachment.created_on&.iso8601,
+          description: attachment.description.presence,
+          url: base_url("/attachments/download/#{attachment.id}/#{ERB::Util.url_encode(attachment.filename)}")
+        }.compact
+      end
+
+      def journals(issue)
+        can_view_private = user.allowed_to?(:view_private_notes, issue.project)
+        issue.journals.preload(:user, :details).order(:created_on, :id).filter_map do |journal|
+          # Same as the web UI: private notes are omitted entirely unless the
+          # user wrote them or may view private notes
+          notes_visible = !journal.private_notes? || journal.user_id == user.id || can_view_private
+          details = journal.visible_details(user).map {|detail| detail_hash(detail)}
+          next if (!notes_visible || journal.notes.blank?) && details.empty?
+
+          {
+            id: journal.id,
+            user: journal.user&.name,
+            created_on: journal.created_on&.iso8601,
+            private_notes: journal.private_notes?,
+            notes: notes_visible ? journal.notes.presence : nil,
+            details: details.presence
+          }.compact
+        end
+      end
+
+      def detail_hash(detail)
+        case detail.property
+        when 'attr'
+          {
+            attribute: detail.prop_key.sub(/_id\z/, ''),
+            old_value: detail_value(detail.prop_key, detail.old_value),
+            new_value: detail_value(detail.prop_key, detail.value)
+          }
+        when 'cf'
+          {
+            attribute: CustomField.find_by_id(detail.prop_key)&.name || "cf_#{detail.prop_key}",
+            old_value: detail.old_value,
+            new_value: detail.value
+          }
+        when 'attachment'
+          {attribute: 'attachment', old_value: detail.old_value, new_value: detail.value}
+        when 'relation'
+          {attribute: "relation (#{detail.prop_key})", old_value: detail.old_value, new_value: detail.value}
+        else
+          {attribute: detail.prop_key, old_value: detail.old_value, new_value: detail.value}
+        end.compact
+      end
+
+      def detail_value(prop_key, value)
+        return nil if value.blank?
+
+        if (resolver = DETAIL_VALUE_CLASSES[prop_key])
+          resolver.call(value) || value
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/get_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/get_issue.rb
@@ -21,16 +21,15 @@ module RedmineMcp
         }
       )
 
-      DETAIL_VALUE_CLASSES = {
-        'status_id' => proc {|v| IssueStatus.find_by_id(v)&.name},
-        'tracker_id' => proc {|v| Tracker.find_by_id(v)&.name},
-        'priority_id' => proc {|v| IssuePriority.find_by_id(v)&.name},
-        'assigned_to_id' => proc {|v| Principal.find_by_id(v)&.name},
-        'author_id' => proc {|v| Principal.find_by_id(v)&.name},
-        'category_id' => proc {|v| IssueCategory.find_by_id(v)&.name},
-        'fixed_version_id' => proc {|v| Version.find_by_id(v)&.name},
-        'project_id' => proc {|v| Project.find_by_id(v)&.identifier},
-        'parent_id' => proc {|v| "##{v}"}
+      # prop_key => the class whose id maps to a display name. Whole tables are
+      # small, so they are loaded once per request (see ref_name) instead of a
+      # find_by_id per journal detail.
+      DETAIL_NAME_CLASSES = {
+        'status_id' => IssueStatus,
+        'tracker_id' => Tracker,
+        'priority_id' => IssuePriority,
+        'category_id' => IssueCategory,
+        'fixed_version_id' => Version
       }.freeze
 
       def call(args)
@@ -85,7 +84,9 @@ module RedmineMcp
 
       def journals(issue)
         can_view_private = user.allowed_to?(:view_private_notes, issue.project)
-        issue.journals.preload(:user, :details).order(:created_on, :id).filter_map do |journal|
+        journals = issue.journals.preload(:user, :details).order(:created_on, :id).to_a
+        @principal_names = principal_name_map(journals)
+        journals.filter_map do |journal|
           # Same as the web UI: private notes are omitted entirely unless the
           # user wrote them or may view private notes
           notes_visible = !journal.private_notes? || journal.user_id == user.id || can_view_private
@@ -113,7 +114,7 @@ module RedmineMcp
           }
         when 'cf'
           {
-            attribute: CustomField.find_by_id(detail.prop_key)&.name || "cf_#{detail.prop_key}",
+            attribute: ref_name(CustomField, detail.prop_key) || "cf_#{detail.prop_key}",
             old_value: detail.old_value,
             new_value: detail.value
           }
@@ -129,11 +130,39 @@ module RedmineMcp
       def detail_value(prop_key, value)
         return nil if value.blank?
 
-        if (resolver = DETAIL_VALUE_CLASSES[prop_key])
-          resolver.call(value) || value
+        case prop_key
+        when *DETAIL_NAME_CLASSES.keys
+          ref_name(DETAIL_NAME_CLASSES[prop_key], value) || value
+        when 'assigned_to_id', 'author_id'
+          @principal_names[value.to_i] || value
+        when 'project_id'
+          project_identifiers[value.to_i] || value
+        when 'parent_id'
+          "##{value}"
         else
           value
         end
+      end
+
+      # id => name for a whole reference table, loaded once per request
+      def ref_name(klass, id)
+        map = (@ref_name_maps ||= {})[klass] ||= klass.pluck(:id, :name).to_h
+        map[id.to_i]
+      end
+
+      def project_identifiers
+        @project_identifiers ||= Project.pluck(:id, :identifier).to_h
+      end
+
+      # Resolve every principal referenced by the details in one query so the
+      # history of a long-lived issue does not fan out into find_by_id calls
+      def principal_name_map(journals)
+        ids = journals.flat_map(&:details).filter_map do |detail|
+          next unless detail.property == 'attr' && %w[assigned_to_id author_id].include?(detail.prop_key)
+
+          [detail.old_value, detail.value]
+        end.flatten.compact.map(&:to_i).uniq
+        Principal.where(id: ids).to_a.to_h {|p| [p.id, p.name]}
       end
     end
   end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/get_wiki_page.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/get_wiki_page.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class GetWikiPage < Base
+      tool_name 'get_wiki_page'
+      description 'Returns a wiki page of a project (the start page when no title is given), ' \
+                  'or the list of all page titles when list is true. ' \
+                  'ruby/ruby development guidelines such as DevelopersMeeting or HowToContribute live in the wiki.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            project: {type: 'string', description: 'Project identifier (see list_projects)'},
+            title: {type: 'string', description: 'Page title. Default: the wiki start page'},
+            list: {type: 'boolean', description: 'Return the titles of all pages instead of one page. Default: false'}
+          },
+          required: ['project']
+        }
+      )
+
+      def call(args)
+        project = find_project!(args['project'])
+        fail!("You are not allowed to view the wiki of #{project.identifier}") unless user.allowed_to?(:view_wiki_pages, project)
+
+        wiki = project.wiki
+        fail!("Project #{project.identifier} has no wiki") unless wiki
+
+        return page_list(project, wiki) if args['list']
+
+        title = args['title'].presence || wiki.start_page
+        page = wiki.find_page(title)
+        unless page&.content && page.visible?(user)
+          fail!("Wiki page not found: #{title}. Use list: true to see available pages.")
+        end
+
+        {
+          project: project.identifier,
+          title: page.title,
+          version: page.content.version,
+          author: page.content.author&.name,
+          updated_on: page.content.updated_on&.iso8601,
+          text_formatting: Setting.text_formatting,
+          text: page.content.text,
+          url: page_url(project, page.title)
+        }
+      end
+
+      private
+
+      def page_list(project, wiki)
+        {
+          project: project.identifier,
+          start_page: wiki.start_page,
+          pages: wiki.pages.order(:title).pluck(:title)
+        }
+      end
+
+      def page_url(project, title)
+        base_url("/projects/#{project.identifier}/wiki/#{ERB::Util.url_encode(title)}")
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/list_issues.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/list_issues.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class ListIssues < Base
+      tool_name 'list_issues'
+      description 'Lists issues with structured filters (project, status, tracker, assignee, ' \
+                  'author, update date), sorted by last update by default. ' \
+                  'For free text search over descriptions and comments use the search tool instead.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            project: {type: 'string', description: 'Project identifier (see list_projects)'},
+            status: {
+              type: 'string',
+              description: "'open' (default), 'closed', 'any', or a status name such as 'Feedback'"
+            },
+            tracker: {type: 'string', description: "Tracker name, e.g. 'Bug' or 'Feature'"},
+            assigned_to: {
+              type: 'string',
+              description: "Assignee login or numeric id, 'me' for yourself, or 'none' for unassigned issues"
+            },
+            author: {type: 'string', description: "Author login or numeric id, or 'me'"},
+            subject: {type: 'string', description: 'Words that must appear in the issue subject'},
+            updated_after: {type: 'string', description: 'Only issues updated at or after this ISO 8601 date/datetime'},
+            created_after: {type: 'string', description: 'Only issues created at or after this ISO 8601 date/datetime'},
+            sort: {
+              type: 'string',
+              enum: %w[updated_on created_on id],
+              description: 'Sort field, descending. Default: updated_on'
+            },
+            limit: {type: 'integer', description: 'Maximum number of results (default 25, max 100)'},
+            offset: {type: 'integer', description: 'Number of results to skip, for pagination'}
+          },
+          required: []
+        }
+      )
+
+      SORT_COLUMNS = %w[updated_on created_on id].freeze
+
+      def call(args)
+        limit, offset = pagination(args)
+        scope = Issue.visible(user)
+        scope = apply_filters(scope, args)
+
+        sort = args['sort'].presence || 'updated_on'
+        fail!("Invalid sort: #{sort}. Available: #{SORT_COLUMNS.join(', ')}") unless SORT_COLUMNS.include?(sort)
+
+        {
+          total_count: scope.count,
+          offset: offset,
+          limit: limit,
+          issues: scope.order(sort => :desc, :id => :desc).offset(offset).limit(limit).
+                    preload(:project, :tracker, :status, :priority, :author, :assigned_to).
+                    map {|issue| issue_summary(issue)}
+        }
+      end
+
+      private
+
+      def apply_filters(scope, args)
+        if args['project'].present?
+          scope = scope.where(project_id: find_project!(args['project']).id)
+        end
+
+        case (status = args['status'].to_s.strip.presence || 'open')
+        when 'open'
+          scope = scope.open
+        when 'closed'
+          scope = scope.open(false)
+        when 'any', 'all', '*'
+          # no filter
+        else
+          scope = scope.where(status_id: resolve_status!(status).id)
+        end
+
+        if args['tracker'].present?
+          tracker = Tracker.sorted.detect {|t| t.name.casecmp?(args['tracker'].to_s.strip)}
+          tracker ||= Tracker.find_by_id(args['tracker']) if /\A\d+\z/.match?(args['tracker'].to_s)
+          fail!("Unknown tracker: #{args['tracker']}. Available: #{Tracker.sorted.pluck(:name).join(', ')}") unless tracker
+
+          scope = scope.where(tracker_id: tracker.id)
+        end
+
+        case args['assigned_to'].to_s.strip
+        when ''
+          # no filter
+        when 'me'
+          scope = scope.assigned_to(user)
+        when 'none'
+          scope = scope.where(assigned_to_id: nil)
+        else
+          scope = scope.assigned_to(resolve_principal!(args['assigned_to']))
+        end
+
+        if args['author'].present?
+          author = args['author'].to_s.strip == 'me' ? user : resolve_principal!(args['author'])
+          scope = scope.where(author_id: author.id)
+        end
+
+        scope = scope.like(args['subject'].to_s) if args['subject'].present?
+
+        if args['updated_after'].present?
+          scope = scope.where("#{Issue.table_name}.updated_on >= ?", parse_time!(args['updated_after'], 'updated_after'))
+        end
+        if args['created_after'].present?
+          scope = scope.where("#{Issue.table_name}.created_on >= ?", parse_time!(args['created_after'], 'created_after'))
+        end
+        scope
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/list_issues.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/list_issues.rb
@@ -76,11 +76,7 @@ module RedmineMcp
         end
 
         if args['tracker'].present?
-          tracker = Tracker.sorted.detect {|t| t.name.casecmp?(args['tracker'].to_s.strip)}
-          tracker ||= Tracker.find_by_id(args['tracker']) if /\A\d+\z/.match?(args['tracker'].to_s)
-          fail!("Unknown tracker: #{args['tracker']}. Available: #{Tracker.sorted.pluck(:name).join(', ')}") unless tracker
-
-          scope = scope.where(tracker_id: tracker.id)
+          scope = scope.where(tracker_id: resolve_tracker!(args['tracker']).id)
         end
 
         case args['assigned_to'].to_s.strip

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/list_issues.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/list_issues.rb
@@ -14,7 +14,8 @@ module RedmineMcp
             project: {type: 'string', description: 'Project identifier (see list_projects)'},
             status: {
               type: 'string',
-              description: "'open' (default), 'closed', 'any', or a status name such as 'Feedback'"
+              description: "'open' (default), 'closed', 'any', or an exact status name " \
+                           "(see project_metadata for valid names, e.g. 'Feedback')"
             },
             tracker: {type: 'string', description: "Tracker name, e.g. 'Bug' or 'Feature'"},
             assigned_to: {
@@ -69,7 +70,7 @@ module RedmineMcp
           scope = scope.open
         when 'closed'
           scope = scope.open(false)
-        when 'any', 'all', '*'
+        when 'any'
           # no filter
         else
           scope = scope.where(status_id: resolve_status!(status).id)

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/list_projects.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/list_projects.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class ListProjects < Base
+      tool_name 'list_projects'
+      description 'Lists the projects visible to you. Use the returned `identifier` ' \
+                  'as the `project` argument of the other tools.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            include_closed: {
+              type: 'boolean',
+              description: 'Also list closed (read-only) projects. Default: false'
+            },
+            limit: {type: 'integer', description: 'Maximum number of results (default 25, max 100)'},
+            offset: {type: 'integer', description: 'Number of results to skip, for pagination'}
+          },
+          required: []
+        }
+      )
+
+      def call(args)
+        limit, offset = pagination(args)
+        scope = Project.visible(user).sorted
+        scope = scope.active unless args['include_closed']
+
+        {
+          total_count: scope.count,
+          offset: offset,
+          limit: limit,
+          projects: scope.offset(offset).limit(limit).map {|project| project_hash(project)}
+        }
+      end
+
+      private
+
+      def project_hash(project)
+        {
+          identifier: project.identifier,
+          name: project.name,
+          description: project.description.to_s.truncate(200),
+          parent: project.parent&.identifier,
+          closed: !project.active?,
+          url: base_url("/projects/#{project.identifier}")
+        }.compact
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/project_metadata.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/project_metadata.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class ProjectMetadata < Base
+      tool_name 'project_metadata'
+      description 'Returns the valid values for issue fields in a project: trackers, ' \
+                  'statuses, priorities, categories, target versions and assignable users. ' \
+                  'Call this before creating or updating issues.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            project: {type: 'string', description: 'Project identifier (see list_projects)'}
+          },
+          required: ['project']
+        }
+      )
+
+      ASSIGNEE_LIMIT = 200
+
+      def call(args)
+        project = find_project!(args['project'])
+        assignees = project.assignable_users.sorted.to_a
+
+        {
+          project: project.identifier,
+          trackers: project.trackers.sorted.map(&:name),
+          statuses: IssueStatus.sorted.map {|s| {name: s.name, closed: s.is_closed?}},
+          priorities: IssuePriority.active.map {|p| {name: p.name, default: p.is_default?}},
+          categories: project.issue_categories.map(&:name),
+          versions: project.shared_versions.sorted.map {|v| {name: v.name, status: v.status}},
+          assignable_users: assignees.first(ASSIGNEE_LIMIT).map {|u| assignee_hash(u)},
+          assignable_users_truncated: assignees.size > ASSIGNEE_LIMIT,
+          permissions: {
+            add_issues: user.allowed_to?(:add_issues, project),
+            edit_issues: user.allowed_to?(:edit_issues, project),
+            add_issue_notes: user.allowed_to?(:add_issue_notes, project),
+            edit_wiki_pages: user.allowed_to?(:edit_wiki_pages, project)
+          }
+        }
+      end
+
+      private
+
+      def assignee_hash(principal)
+        hash = {id: principal.id, name: principal.name}
+        hash[:login] = principal.login if principal.is_a?(User)
+        hash
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/project_metadata.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/project_metadata.rb
@@ -21,7 +21,9 @@ module RedmineMcp
 
       def call(args)
         project = find_project!(args['project'])
-        assignees = project.assignable_users.sorted.to_a
+        # assignable_users is already sorted; fetch one past the limit at the DB
+        # level so huge projects do not load every member just to truncate.
+        assignees = project.assignable_users.limit(ASSIGNEE_LIMIT + 1).to_a
 
         {
           project: project.identifier,

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/search.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/search.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class Search < Base
+      tool_name 'search'
+      description 'Full-text search across issues (subject, description, notes), wiki pages ' \
+                  'and other content, like the search box in the web UI. ' \
+                  'Returns brief matches; use get_issue or get_wiki_page for the full content. ' \
+                  'For structured filtering (by status, assignee, dates...) use list_issues instead.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            q: {type: 'string', description: 'Words to search for. All words must match.'},
+            project: {type: 'string', description: 'Restrict the search to this project identifier'},
+            types: {
+              type: 'array',
+              items: {type: 'string'},
+              description: "Content types to search. Available: issues, wiki_pages, news, documents, " \
+                           "changesets, messages, projects. Default: ['issues', 'wiki_pages']"
+            },
+            titles_only: {type: 'boolean', description: 'Search titles/subjects only. Default: false'},
+            open_issues: {type: 'boolean', description: 'Match open issues only. Default: false'},
+            limit: {type: 'integer', description: 'Maximum number of results (default 25, max 100)'},
+            offset: {type: 'integer', description: 'Number of results to skip, for pagination'}
+          },
+          required: ['q']
+        }
+      )
+
+      DEFAULT_TYPES = %w[issues wiki_pages].freeze
+
+      def call(args)
+        question = args['q'].to_s.strip
+        fail!('Missing required argument: q') if question.blank?
+
+        limit, offset = pagination(args)
+        types = Array(args['types']).map(&:to_s)
+        types = DEFAULT_TYPES.dup if types.empty?
+        unknown = types - Redmine::Search.available_search_types
+        fail!("Unknown types: #{unknown.join(', ')}. Available: #{Redmine::Search.available_search_types.join(', ')}") if unknown.any?
+
+        projects = args['project'].present? ? [find_project!(args['project'])] : nil
+        fetcher = Redmine::Search::Fetcher.new(
+          question, user, types, projects,
+          all_words: true,
+          titles_only: !!args['titles_only'],
+          attachments: '0',
+          open_issues: !!args['open_issues'],
+          cache: false
+        )
+
+        {
+          query: question,
+          total_count: fetcher.result_count,
+          offset: offset,
+          limit: limit,
+          results: fetcher.results(offset, limit).map {|record| result_hash(record)}
+        }
+      end
+
+      private
+
+      def result_hash(record)
+        {
+          type: record.class.name.underscore,
+          title: record.event_title,
+          datetime: record.event_datetime&.iso8601,
+          description: record.event_description.to_s.truncate(300),
+          issue_id: record.is_a?(Issue) ? record.id : nil,
+          url: event_url(record)
+        }.compact
+      end
+
+      def event_url(record)
+        base_url(Rails.application.routes.url_for(record.event_url.merge(only_path: true)))
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class UpdateIssue < Base
+      tool_name 'update_issue'
+      description 'Adds a comment to an issue and/or changes its attributes ' \
+                  '(status, assignee, priority, subject, description, category, version, done ratio). ' \
+                  'Status changes are validated against the workflow; on rejection the error lists ' \
+                  'the transitions available to you.'
+      input_schema(
+        {
+          type: 'object',
+          properties: {
+            id: {type: 'integer', description: 'Issue id'},
+            notes: {type: 'string', description: 'Comment to add, in the wiki text formatting reported by whoami'},
+            private_notes: {type: 'boolean', description: 'Make the comment visible only to users allowed to view private notes'},
+            status: {type: 'string', description: "New status name, e.g. 'Closed' or 'Feedback'"},
+            assigned_to: {type: 'string', description: "New assignee login or numeric id, or 'none' to unassign"},
+            priority: {type: 'string', description: 'New priority name'},
+            subject: {type: 'string', description: 'New subject'},
+            description: {type: 'string', description: 'New description (replaces the current one)'},
+            category: {type: 'string', description: 'New category name'},
+            version: {type: 'string', description: "New target version name, or 'none' to clear"},
+            done_ratio: {type: 'integer', description: 'Percent done, 0-100'}
+          },
+          required: ['id']
+        }
+      )
+
+      ATTRIBUTE_KEYS = %w[status assigned_to priority subject description category version done_ratio].freeze
+
+      def call(args)
+        issue = find_issue!(args['id'])
+
+        wants_notes = args['notes'].present?
+        wants_attributes = ATTRIBUTE_KEYS.any? {|key| args.key?(key)}
+        fail!('Nothing to do: provide notes and/or attributes to change') unless wants_notes || wants_attributes
+
+        if wants_notes && !issue.notes_addable?(user)
+          fail!("You are not allowed to add notes to issue ##{issue.id}")
+        end
+        if wants_attributes && !issue.attributes_editable?(user)
+          fail!("You are not allowed to edit issue ##{issue.id}")
+        end
+
+        issue.init_journal(user, args['notes'].to_s)
+        issue.send(:safe_attributes=, build_attributes(issue, args), user)
+
+        if issue.save
+          {updated: true}.merge(issue_summary(issue))
+        else
+          fail!("Issue could not be updated: #{issue.errors.full_messages.join(', ')}")
+        end
+      end
+
+      private
+
+      def build_attributes(issue, args)
+        project = issue.project
+        attrs = {}
+        attrs['private_notes'] = true if args['private_notes'] && args['notes'].present?
+        attrs['status_id'] = new_status_id(issue, args['status']) if args['status'].present?
+        attrs['subject'] = args['subject'].to_s if args.key?('subject')
+        attrs['description'] = args['description'].to_s if args.key?('description')
+        attrs['priority_id'] = resolve_priority!(args['priority']).id if args['priority'].present?
+        attrs['done_ratio'] = args['done_ratio'].to_i if args.key?('done_ratio')
+
+        case args['assigned_to'].to_s.strip
+        when ''
+          # not requested
+        when 'none'
+          attrs['assigned_to_id'] = ''
+        else
+          attrs['assigned_to_id'] = resolve_principal!(args['assigned_to']).id
+        end
+
+        if args['category'].present?
+          category = project.issue_categories.detect {|c| c.name.casecmp?(args['category'].to_s.strip)}
+          category || fail!("Unknown category: #{args['category']}. Available: #{project.issue_categories.map(&:name).join(', ')}")
+          attrs['category_id'] = category.id
+        end
+
+        case args['version'].to_s.strip
+        when ''
+          # not requested
+        when 'none'
+          attrs['fixed_version_id'] = ''
+        else
+          version = project.shared_versions.detect {|v| v.name.casecmp?(args['version'].to_s.strip)}
+          version || fail!("Unknown version: #{args['version']}. Available: #{project.shared_versions.map(&:name).join(', ')}")
+          attrs['fixed_version_id'] = version.id
+        end
+
+        attrs
+      end
+
+      def new_status_id(issue, value)
+        status = resolve_status!(value)
+        return status.id if status.id == issue.status_id
+
+        allowed = issue.new_statuses_allowed_to(user)
+        unless allowed.include?(status)
+          fail!("Cannot change status of ##{issue.id} from '#{issue.status.name}' to '#{status.name}'. " \
+                "Transitions allowed to you: #{allowed.map(&:name).join(', ')}")
+        end
+        status.id
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
@@ -75,11 +75,7 @@ module RedmineMcp
           attrs['assigned_to_id'] = resolve_principal!(args['assigned_to']).id
         end
 
-        if args['category'].present?
-          category = project.issue_categories.detect {|c| c.name.casecmp?(args['category'].to_s.strip)}
-          category || fail!("Unknown category: #{args['category']}. Available: #{project.issue_categories.map(&:name).join(', ')}")
-          attrs['category_id'] = category.id
-        end
+        attrs['category_id'] = resolve_category!(project, args['category']).id if args['category'].present?
 
         case args['version'].to_s.strip
         when ''
@@ -87,9 +83,7 @@ module RedmineMcp
         when 'none'
           attrs['fixed_version_id'] = ''
         else
-          version = project.shared_versions.detect {|v| v.name.casecmp?(args['version'].to_s.strip)}
-          version || fail!("Unknown version: #{args['version']}. Available: #{project.shared_versions.map(&:name).join(', ')}")
-          attrs['fixed_version_id'] = version.id
+          attrs['fixed_version_id'] = resolve_version!(project, args['version']).id
         end
 
         attrs

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
@@ -43,6 +43,11 @@ module RedmineMcp
         if wants_attributes && !issue.attributes_editable?(user)
           fail!("You are not allowed to edit issue ##{issue.id}")
         end
+        # safe_attributes= silently drops private_notes without this permission,
+        # which would post the note publicly. Reject up front instead.
+        if args['private_notes'] && wants_notes && !user.allowed_to?(:set_notes_private, issue.project)
+          fail!("You are not allowed to add private notes to issue ##{issue.id}")
+        end
 
         issue.init_journal(user, args['notes'].to_s)
         issue.send(:safe_attributes=, build_attributes(issue, args), user)

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/update_issue.rb
@@ -22,13 +22,19 @@ module RedmineMcp
             description: {type: 'string', description: 'New description (replaces the current one)'},
             category: {type: 'string', description: 'New category name'},
             version: {type: 'string', description: "New target version name, or 'none' to clear"},
-            done_ratio: {type: 'integer', description: 'Percent done, 0-100'}
+            done_ratio: {type: 'integer', description: 'Percent done, 0-100'},
+            custom_fields: {
+              type: 'object',
+              description: 'Custom field values to change, keyed by field name, ' \
+                           "e.g. {\"ruby -v\": \"ruby 3.4.0\", \"Backport\": \"3.3: REQUIRED\"}",
+              additionalProperties: {type: 'string'}
+            }
           },
           required: ['id']
         }
       )
 
-      ATTRIBUTE_KEYS = %w[status assigned_to priority subject description category version done_ratio].freeze
+      ATTRIBUTE_KEYS = %w[status assigned_to priority subject description category version done_ratio custom_fields].freeze
 
       def call(args)
         issue = find_issue!(args['id'])
@@ -89,6 +95,10 @@ module RedmineMcp
           attrs['fixed_version_id'] = ''
         else
           attrs['fixed_version_id'] = resolve_version!(project, args['version']).id
+        end
+
+        if args['custom_fields'].is_a?(Hash)
+          attrs['custom_field_values'] = custom_field_values!(project, args['custom_fields'])
         end
 
         attrs

--- a/plugins/redmine_mcp/lib/redmine_mcp/tools/whoami.rb
+++ b/plugins/redmine_mcp/lib/redmine_mcp/tools/whoami.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RedmineMcp
+  module Tools
+    class Whoami < Base
+      tool_name 'whoami'
+      description 'Returns the user account associated with the API key, ' \
+                  'the wiki text formatting used for issue descriptions and notes, ' \
+                  'and the projects the user is a member of. ' \
+                  'Useful to verify authentication before doing anything else.'
+      input_schema({type: 'object', properties: {}, required: []})
+
+      def call(_args)
+        {
+          id: user.id,
+          login: user.login,
+          name: user.name,
+          admin: user.admin?,
+          text_formatting: Setting.text_formatting,
+          site: base_url('/'),
+          member_of: user.memberships.preload(:project).filter_map {|m| m.project&.identifier}.sort
+        }
+      end
+    end
+  end
+end

--- a/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
+++ b/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
@@ -283,6 +283,19 @@ class McpEndpointTest < Redmine::IntegrationTest
     end
   end
 
+  def test_update_issue_custom_field
+    data = call_tool('update_issue',
+                     {'id' => 1, 'custom_fields' => {'Searchable field' => 'updated via MCP'}})
+    assert data['updated']
+    assert_equal 'updated via MCP', Issue.find(1).custom_field_value(2)
+  end
+
+  def test_update_issue_unknown_custom_field_is_rejected
+    data = call_tool('update_issue',
+                     {'id' => 1, 'custom_fields' => {'No Such Field' => 'x'}}, error: true)
+    assert_match /Unknown custom field/, data
+  end
+
   def test_get_wiki_page
     data = call_tool('get_wiki_page', {'project' => 'ecookbook'})
     assert_equal 'CookBook_documentation', data['title']

--- a/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
+++ b/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
@@ -186,6 +186,19 @@ class McpEndpointTest < Redmine::IntegrationTest
     assert data['journals'].any? {|j| j['notes'] == 'a public note'}
   end
 
+  # Guards the batched id->name resolution for attribute change details
+  def test_get_issue_resolves_named_detail_changes
+    issue = Issue.find(1)
+    issue.init_journal(User.find(1))
+    issue.assigned_to_id = 3
+    issue.status_id = 2
+    issue.save!
+
+    details = call_tool('get_issue', {'id' => 1})['journals'].flat_map {|j| j['details'] || []}
+    assert_equal Principal.find(3).name, details.detect {|d| d['attribute'] == 'assigned_to'}['new_value']
+    assert_equal IssueStatus.find(2).name, details.detect {|d| d['attribute'] == 'status'}['new_value']
+  end
+
   def test_get_issue_hides_private_notes
     Role.find(1).remove_permission!(:view_private_notes)
     Journal.create!(journalized: Issue.find(1), user: User.find(1),

--- a/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
+++ b/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
@@ -145,6 +145,12 @@ class McpEndpointTest < Redmine::IntegrationTest
     assert_match /Unknown status/, data
   end
 
+  # 'any' is the only no-filter keyword; 'all'/'*' are not aliases
+  def test_list_issues_all_is_not_a_status_alias
+    data = call_tool('list_issues', {'status' => 'all'}, error: true)
+    assert_match /Unknown status/, data
+  end
+
   def test_search
     data = call_tool('search', {'q' => 'recipe'})
     assert_operator data['total_count'], :>, 0

--- a/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
+++ b/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
@@ -43,6 +43,12 @@ class McpEndpointTest < Redmine::IntegrationTest
     assert_equal({}, JSON.parse(response.body)['result'])
   end
 
+  def test_invalid_bearer_token_is_rejected
+    mcp_post({jsonrpc: '2.0', id: 1, method: 'ping'}, key: nil,
+             headers: {'HTTP_AUTHORIZATION' => 'Bearer not-a-real-key'})
+    assert_response :unauthorized
+  end
+
   def test_rejects_non_json_content_type
     post '/mcp', params: 'jsonrpc',
                  headers: {'CONTENT_TYPE' => 'text/plain', 'HTTP_X_REDMINE_API_KEY' => @key}
@@ -151,6 +157,20 @@ class McpEndpointTest < Redmine::IntegrationTest
     assert_match /Unknown status/, data
   end
 
+  def test_list_issues_with_subject_filter
+    match = call_tool('list_issues', {'project' => 'ecookbook', 'status' => 'any', 'subject' => 'recipe'})
+    assert_operator match['total_count'], :>, 0
+    none = call_tool('list_issues', {'project' => 'ecookbook', 'status' => 'any', 'subject' => 'zzznomatchzzz'})
+    assert_equal 0, none['total_count']
+  end
+
+  def test_list_issues_with_updated_after_filter
+    past = call_tool('list_issues', {'status' => 'any', 'updated_after' => '2000-01-01'})
+    assert_operator past['total_count'], :>, 0
+    future = call_tool('list_issues', {'status' => 'any', 'updated_after' => '2999-01-01'})
+    assert_equal 0, future['total_count']
+  end
+
   def test_search
     data = call_tool('search', {'q' => 'recipe'})
     assert_operator data['total_count'], :>, 0
@@ -241,6 +261,26 @@ class McpEndpointTest < Redmine::IntegrationTest
   def test_update_issue_requires_something_to_do
     data = call_tool('update_issue', {'id' => 1}, error: true)
     assert_match /Nothing to do/, data
+  end
+
+  def test_update_issue_private_note
+    Role.find(1).add_permission!(:set_notes_private)
+    data = call_tool('update_issue', {'id' => 1, 'notes' => 'secret', 'private_notes' => true})
+    assert data['updated']
+    journal = Issue.find(1).journals.last
+    assert journal.private_notes?
+    assert_equal 'secret', journal.notes
+  end
+
+  # Without set_notes_private, safe_attributes= would silently post the note
+  # publicly; the tool must reject it instead of leaking it.
+  def test_update_issue_private_note_without_permission_is_rejected
+    Role.find(1).remove_permission!(:set_notes_private)
+    assert_no_difference 'Journal.count' do
+      data = call_tool('update_issue',
+                       {'id' => 1, 'notes' => 'secret', 'private_notes' => true}, error: true)
+      assert_match /not allowed to add private notes/, data
+    end
   end
 
   def test_get_wiki_page

--- a/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
+++ b/plugins/redmine_mcp/test/integration/mcp_endpoint_test.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+
+class McpEndpointTest < Redmine::IntegrationTest
+  def setup
+    super
+    Setting.rest_api_enabled = '1'
+    Setting.notified_events = []
+    @user = User.find(2) # jsmith, member of ecookbook and onlinestore
+    @key = Token.create!(user: @user, action: 'api').value
+  end
+
+  def teardown
+    Setting.rest_api_enabled = '0'
+  end
+
+  # someone (user 7) has no memberships, so private projects are invisible
+  def outsider_key
+    @outsider_key ||= Token.create!(user: User.find(7), action: 'api').value
+  end
+
+  def test_get_is_not_allowed
+    get '/mcp'
+    assert_response :method_not_allowed
+    assert_equal 'POST', response.headers['Allow']
+  end
+
+  def test_anonymous_request_is_rejected
+    mcp_post({jsonrpc: '2.0', id: 1, method: 'ping'}, key: nil)
+    assert_response :unauthorized
+  end
+
+  def test_invalid_api_key_is_rejected
+    mcp_post({jsonrpc: '2.0', id: 1, method: 'ping'}, key: 'wrong-key')
+    assert_response :unauthorized
+  end
+
+  def test_authentication_with_bearer_token
+    mcp_post({jsonrpc: '2.0', id: 1, method: 'ping'}, key: nil,
+             headers: {'HTTP_AUTHORIZATION' => "Bearer #{@key}"})
+    assert_response :success
+    assert_equal({}, JSON.parse(response.body)['result'])
+  end
+
+  def test_rejects_non_json_content_type
+    post '/mcp', params: 'jsonrpc',
+                 headers: {'CONTENT_TYPE' => 'text/plain', 'HTTP_X_REDMINE_API_KEY' => @key}
+    assert_response :bad_request
+  end
+
+  def test_malformed_json_is_rejected
+    # Rails' JSON parameter parsing middleware rejects the body before the
+    # controller runs
+    post '/mcp', params: '{invalid',
+                 headers: {'CONTENT_TYPE' => 'application/json', 'HTTP_X_REDMINE_API_KEY' => @key}
+    assert_response :bad_request
+  end
+
+  def test_empty_body_returns_parse_error
+    post '/mcp', params: '',
+                 headers: {'CONTENT_TYPE' => 'application/json', 'HTTP_X_REDMINE_API_KEY' => @key}
+    assert_response :success
+    assert_equal(-32700, JSON.parse(response.body)['error']['code'])
+  end
+
+  def test_unknown_method
+    response_json = rpc('no/such/method')
+    assert_equal(-32601, response_json['error']['code'])
+  end
+
+  def test_notification_is_accepted_without_body
+    mcp_post({jsonrpc: '2.0', method: 'notifications/initialized'})
+    assert_response :accepted
+    assert_empty response.body
+  end
+
+  def test_initialize
+    result = rpc('initialize', {'protocolVersion' => '2025-06-18'})['result']
+    assert_equal '2025-06-18', result['protocolVersion']
+    assert_equal 'redmine-mcp', result['serverInfo']['name']
+    assert result['capabilities'].key?('tools')
+  end
+
+  def test_initialize_with_unsupported_protocol_version_offers_latest
+    result = rpc('initialize', {'protocolVersion' => '1999-01-01'})['result']
+    assert_equal RedmineMcp::Server::PROTOCOL_VERSIONS.first, result['protocolVersion']
+  end
+
+  def test_tools_list
+    result = rpc('tools/list')['result']
+    names = result['tools'].map {|t| t['name']}
+    expected = %w[whoami list_projects project_metadata search list_issues
+                  get_issue create_issue update_issue get_wiki_page]
+    assert_equal expected.sort, names.sort
+    result['tools'].each do |tool|
+      assert tool['description'].present?, "#{tool['name']} has no description"
+      assert_equal 'object', tool['inputSchema']['type']
+    end
+  end
+
+  def test_whoami
+    data = call_tool('whoami')
+    assert_equal 'jsmith', data['login']
+    assert_equal @user.id, data['id']
+    assert_includes data['member_of'], 'ecookbook'
+  end
+
+  def test_list_projects
+    data = call_tool('list_projects')
+    identifiers = data['projects'].map {|p| p['identifier']}
+    assert_includes identifiers, 'ecookbook'
+    assert_includes identifiers, 'onlinestore'
+  end
+
+  def test_list_projects_excludes_invisible_private_projects
+    data = call_tool('list_projects', {}, key: outsider_key)
+    identifiers = data['projects'].map {|p| p['identifier']}
+    assert_includes identifiers, 'ecookbook'
+    # onlinestore is private and someone is not a member
+    assert_not_includes identifiers, 'onlinestore'
+  end
+
+  def test_project_metadata
+    data = call_tool('project_metadata', {'project' => 'ecookbook'})
+    assert_includes data['trackers'], 'Bug'
+    assert data['statuses'].any? {|s| s['closed']}
+    assert data['priorities'].any?
+    assert data['assignable_users'].any? {|u| u['login'] == 'jsmith'}
+    assert data['permissions']['add_issues']
+  end
+
+  def test_list_issues_with_filters
+    data = call_tool('list_issues', {'project' => 'ecookbook', 'status' => 'any', 'limit' => 5})
+    assert_operator data['total_count'], :>, 0
+    assert_operator data['issues'].size, :<=, 5
+    data = call_tool('list_issues', {'assigned_to' => 'me', 'status' => 'any'})
+    data['issues'].each do |issue|
+      assert_equal @user.name, issue['assigned_to']
+    end
+  end
+
+  def test_list_issues_rejects_unknown_status
+    data = call_tool('list_issues', {'status' => 'Nonexistent'}, error: true)
+    assert_match /Unknown status/, data
+  end
+
+  def test_search
+    data = call_tool('search', {'q' => 'recipe'})
+    assert_operator data['total_count'], :>, 0
+    assert data['results'].all? {|r| r['url'].present?}
+  end
+
+  def test_get_issue_with_journals
+    Journal.create!(journalized: Issue.find(1), user: User.find(1), notes: 'a public note')
+    data = call_tool('get_issue', {'id' => 1})
+    assert_equal 1, data['id']
+    assert data['subject'].present?
+    assert data['url'].end_with?('/issues/1')
+    assert data['journals'].any? {|j| j['notes'] == 'a public note'}
+  end
+
+  def test_get_issue_hides_private_notes
+    Role.find(1).remove_permission!(:view_private_notes)
+    Journal.create!(journalized: Issue.find(1), user: User.find(1),
+                    notes: 'secret note', private_notes: true)
+    data = call_tool('get_issue', {'id' => 1})
+    assert(data['journals'].none? {|j| j['notes'] == 'secret note'})
+  end
+
+  def test_get_issue_not_visible
+    issue = Issue.generate!(project_id: 2) # onlinestore, invisible to someone
+    data = call_tool('get_issue', {'id' => issue.id}, key: outsider_key, error: true)
+    assert_match /not found or not visible/, data
+  end
+
+  def test_create_issue
+    assert_difference 'Issue.count' do
+      data = call_tool('create_issue', {
+        'project' => 'ecookbook',
+        'subject' => 'MCP created issue',
+        'description' => 'created through MCP',
+        'tracker' => 'Bug'
+      })
+      assert data['created']
+      assert_equal 'MCP created issue', data['subject']
+      assert_equal 'Bug', data['tracker']
+    end
+    issue = Issue.order(:id).last
+    assert_equal @user, issue.author
+  end
+
+  def test_create_issue_without_permission
+    data = call_tool('create_issue', {'project' => 'onlinestore', 'subject' => 'x'},
+                     key: outsider_key, error: true)
+    assert_match /not found or not visible/, data
+  end
+
+  def test_create_issue_with_unknown_tracker
+    data = call_tool('create_issue',
+                     {'project' => 'ecookbook', 'subject' => 'x', 'tracker' => 'Nope'},
+                     error: true)
+    assert_match /Unknown tracker/, data
+  end
+
+  def test_update_issue_add_note
+    assert_difference 'Journal.count' do
+      data = call_tool('update_issue', {'id' => 1, 'notes' => 'noted via MCP'})
+      assert data['updated']
+    end
+    assert_equal 'noted via MCP', Issue.find(1).journals.last.notes
+  end
+
+  def test_update_issue_change_status
+    issue = Issue.find(1)
+    allowed = issue.new_statuses_allowed_to(@user)
+    skip 'no workflow transition available in fixtures' if allowed.empty?
+
+    target = allowed.first
+    data = call_tool('update_issue', {'id' => 1, 'status' => target.name})
+    assert_equal target.name, data['status']
+    assert_equal target, issue.reload.status
+  end
+
+  def test_update_issue_rejects_disallowed_status
+    WorkflowTransition.delete_all
+    issue = Issue.find(1)
+    forbidden = IssueStatus.all.detect {|s| s != issue.status}
+
+    data = call_tool('update_issue', {'id' => 1, 'status' => forbidden.name}, error: true)
+    assert_match /Transitions allowed to you/, data
+    assert_not_equal forbidden, issue.reload.status
+  end
+
+  def test_update_issue_requires_something_to_do
+    data = call_tool('update_issue', {'id' => 1}, error: true)
+    assert_match /Nothing to do/, data
+  end
+
+  def test_get_wiki_page
+    data = call_tool('get_wiki_page', {'project' => 'ecookbook'})
+    assert_equal 'CookBook_documentation', data['title']
+    assert data['text'].present?
+  end
+
+  def test_get_wiki_page_list
+    data = call_tool('get_wiki_page', {'project' => 'ecookbook', 'list' => true})
+    assert_includes data['pages'], 'CookBook_documentation'
+  end
+
+  private
+
+  def mcp_post(body, key: @key, headers: {})
+    all_headers = {'CONTENT_TYPE' => 'application/json'}
+    all_headers['HTTP_X_REDMINE_API_KEY'] = key if key
+    post '/mcp', params: body.to_json, headers: all_headers.merge(headers)
+  end
+
+  def rpc(method, params = {}, key: @key)
+    mcp_post({jsonrpc: '2.0', id: 1, method: method, params: params}, key: key)
+    assert_response :success
+    JSON.parse(response.body)
+  end
+
+  # Calls a tool and returns the parsed JSON payload, or the raw error text
+  # when error: true
+  def call_tool(name, arguments = {}, key: @key, error: false)
+    response_json = rpc('tools/call', {'name' => name, 'arguments' => arguments}, key: key)
+    assert_nil response_json['error'], "unexpected JSON-RPC error: #{response_json['error'].inspect}"
+    result = response_json['result']
+    text = result['content'].first['text']
+    if error
+      assert result['isError'], "expected a tool error but got: #{text}"
+      text
+    else
+      assert_not result['isError'], "unexpected tool error: #{text}"
+      JSON.parse(text)
+    end
+  end
+end


### PR DESCRIPTION
This adds a redmine_mcp plugin that serves a Model Context Protocol endpoint at POST /mcp so that AI coding agents can search, read, create and update issues and read wiki pages while working on ruby/ruby. The goal is to let agents interact with bugs.ruby-lang.org through the same data and permission model as the web UI instead of scraping HTML or hand-rolling REST calls.

Authentication reuses the per-user Redmine REST API key, accepted via the X-Redmine-API-Key header, an Authorization Bearer header or HTTP Basic. Every tool call runs as the key owner, so issue visibility, private notes, workflow transitions and mass-assignment safety are all enforced by the existing Redmine layer rather than reimplemented. The transport is the stateless form of Streamable HTTP, answering each JSON-RPC request with a single JSON response.

The server exposes nine tools covering identity, project discovery and metadata, full-text search, structured issue listing, full issue reads including the comment history, issue creation and update, and wiki page reads. Writes go through safe_attributes and init_journal, and status changes are validated against the workflow with an error that lists the transitions available to the caller.

The endpoint ships with an integration test suite covering authentication, protocol negotiation, visibility enforcement and the read and write paths. The last three commits apply hardening from an adversarial review of the initial implementation. They stop the generic error path from returning internal exception class names, factor duplicated issue field resolution into shared helpers, and drop two undocumented status filter aliases so the accepted values match the advertised schema.
