### PR TITLE
Fix PG::UndefinedColumn on tags.color after redmineup_tags 2.1.2

### DIFF
--- a/plugins/redmineup_tags/db/migrate/003_add_color_to_tags.rb
+++ b/plugins/redmineup_tags/db/migrate/003_add_color_to_tags.rb
@@ -1,0 +1,13 @@
+class AddColorToTags < ActiveRecord::Migration[8.1]
+  # The tags table on this instance was created by an old plugin version
+  # without the color column. 002_create_tags.rb is guarded by
+  # table_exists? and never adds it, so redmineup_tags 2.1.2 fails with
+  # PG::UndefinedColumn. add_tags_column is a no-op when the column
+  # already exists (fresh installs).
+  def self.up
+    ActiveRecord::Base.add_tags_column(:tags, name: :color, type: :integer, default: nil)
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Production started raising `ActiveRecord::StatementInvalid: PG::UndefinedColumn: column tags.color does not exist` after the redmineup_tags 2.1.2 update, because `Issue.all_tags` now selects `tags.color`. The production `tags` table was created by an older plugin version without that column. The plugin's `002_create_tags.rb` never adds it because `create_taggable_table` is guarded by `table_exists?`.

This adds a plugin migration that calls the gem-provided `ActiveRecord::Base.add_tags_column`, which is guarded by `column_exists?` and is therefore a no-op on fresh installs where `002` already created the column. The column type is `:integer` to match `create_taggable_table` and the redmineup 1.1.10 `Tag` model. Its `color` getter formats the stored integer as `#%06x` and its setter converts hex strings with `.hex`, so the string type shown in the gem's doc example would be wrong.

Verified locally on both paths. With the column already present the migration succeeds as a no-op. With the column dropped to reproduce the production state, `rake redmine:plugins:migrate` adds `color integer` and `Issue.all_tags` runs successfully.

Datadog Error Tracking issue 16b6af20-75ff-11f1-b0b2-da7ad0900000

Generated with [Claude Code](https://claude.com/claude-code)
