### PR TITLE
Rename Datadog APM service to bugs-ruby-lang

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -5,7 +5,7 @@ Datadog.configure do |c|
   c.profiling.enabled = true
   c.runtime_metrics.enabled = true
   c.env = 'prod'
-  c.service = 'redmine_app'
+  c.service = 'bugs-ruby-lang'
   c.version = ENV['HEROKU_RELEASE_VERSION']
   c.tracing.instrument :pg, comment_propagation: 'full'
   c.tracing.instrument :redis


### PR DESCRIPTION
Align the APM service name with the Heroku app name and the service tag already used by the log drain. Datadog treats a rename as a new service, so Error Tracking issues, the Service page history, and profiling timelines restart under bugs-ruby-lang; pre-rename history remains queryable under redmine_app. The env tag stays prod, which has over a year of APM history. Integration child services (postgres, pg, redis, active_support-cache, net/http, aws) are named independently and are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)