### PR TITLE
Unify integration span service names under bugs-ruby-lang

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -7,6 +7,7 @@ Datadog.configure do |c|
   c.env = 'prod'
   c.service = 'bugs-ruby-lang'
   c.version = ENV['HEROKU_RELEASE_VERSION']
+  c.tracing.contrib.global_default_service_name.enabled = true
   c.tracing.instrument :pg, comment_propagation: 'full'
   c.tracing.instrument :redis
 end


### PR DESCRIPTION
Enable global_default_service_name (equivalent to DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED) so integration spans from pg, postgres, redis, active_support-cache, net/http, and aws carry the application service name instead of forming separate pseudo-services. Datadog represents the downstream dependencies as inferred entities. This resolves the six integration overrides flagged on the Service Remapping page, and doing it together with the service rename means the telemetry history resets only once. No monitors, dashboards, retention filters, or saved views reference the old integration service names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)