### PR TITLE
Replace NEW_RELIC_APP_NAME with HEROKU_APP_NAME for staging detection

### DIFF
--- a/app/middlewares/yjit_stats_middleware.rb
+++ b/app/middlewares/yjit_stats_middleware.rb
@@ -2,7 +2,7 @@
 require 'datadog/statsd'
 
 class YjitStatsMiddleware
-  STAGING = ENV.fetch('NEW_RELIC_APP_NAME') == 'staging-bugs-ruby-lang'
+  STAGING = ENV['HEROKU_APP_NAME'] == 'staging-bugs-ruby-lang'
   YJIT_STATS_REQUEST_INTERVAL = STAGING ? 1 : 10
   YJIT_STATS_STRING_REQUEST_INTERVAL = STAGING ? 10 : 1000
 


### PR DESCRIPTION
`NEW_RELIC_APP_NAME` is a leftover from the removed New Relic integration. The `newrelic` gem is not in the Gemfile and this env var's only remaining role is the staging-vs-production discriminator in `YjitStatsMiddleware`, which controls the YJIT stats sampling intervals and the Datadog `env` tag. This switches it to `HEROKU_APP_NAME` provided by the `runtime-dyno-metadata` labs feature, which I confirmed is enabled on both `bugs-ruby-lang` and `staging-bugs-ruby-lang`. The nil-tolerant `ENV[]` form also fixes local dev/test boot, where the previous `ENV.fetch` raised `KeyError` during eager loading unless the env var was set.

After merge and deploy, the leftover config vars can be removed with `heroku config:unset NEW_RELIC_APP_NAME NEW_RELIC_ID -a bugs-ruby-lang` and the same on `staging-bugs-ruby-lang`. `NEW_RELIC_ID` is already unreferenced in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)