### PR TITLE
Move Datadog service, env, and service-name flag to config vars

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -4,10 +4,7 @@ require 'datadog'
 Datadog.configure do |c|
   c.profiling.enabled = true
   c.runtime_metrics.enabled = true
-  c.env = 'prod'
-  c.service = 'bugs-ruby-lang'
   c.version = ENV['HEROKU_RELEASE_VERSION']
-  c.tracing.contrib.global_default_service_name.enabled = true
   c.tracing.instrument :pg, comment_propagation: 'full'
   c.tracing.instrument :redis
 end


### PR DESCRIPTION
With datadog/auto_instrument in Gemfile.local, the pg integration is patched at bundler require time and Redmine issues database queries while booting, so pg memoized its service name as pg before config/initializers/datadog.rb could enable global_default_service_name. That left pg.async.exec spans outside the unified bugs-ruby-lang service after the rename. The values now live in Heroku config vars (DD_SERVICE, DD_ENV, DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED, set as v943), which are correct from process start and also cover spans emitted during boot. This removes the initializer lines they replace so the config vars remain the single source of truth. Profiling, runtime metrics, version tagging, and the pg/redis instrument options stay in the initializer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)