### PR TITLE
Silence Datadog log noise from builds, release phase, and one-off dynos

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# Datadog startup configuration lines are emitted by datadog/auto_instrument
+# when the gem is loaded, before initializers run, so this must be set here
+# rather than in config/initializers/datadog.rb.
+ENV['DD_TRACE_STARTUP_LOGS'] ||= 'false'
+
+# The Datadog Heroku buildpack exports DD_TAGS containing an empty "version:"
+# tag (DD_VERSION is unset; the version is set in config/initializers/datadog.rb
+# instead), which the datadog gem rejects with a WARN twice per boot. Drop
+# malformed tags before the gem parses them.
+if ENV['DD_TAGS']
+  ENV['DD_TAGS'] = ENV['DD_TAGS'].split(/[\s,]+/).reject { |t| t.end_with?(':') }.join(',')
+end
+
 # Rack 3.1.14 or later sets default limits of 4MB for query string bytesize
 # and 4096 for the number of query parameters. These limits are too low
 # for Redmine and can cause the following issues:

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -10,4 +10,12 @@ Datadog.configure do |c|
   c.tracing.contrib.global_default_service_name.enabled = true
   c.tracing.instrument :pg, comment_propagation: 'full'
   c.tracing.instrument :redis
+
+  # Build-time rake tasks (assets:precompile, assets:clean) run without an
+  # agent, so emitting traces only produces ECONNREFUSED errors in build logs.
+  if File.basename($PROGRAM_NAME) == 'rake'
+    c.tracing.enabled = false
+    c.profiling.enabled = false
+    c.runtime_metrics.enabled = false
+  end
 end

--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Sourced by the Datadog Heroku buildpack before starting the agent.
+# Dynos cannot create /var/run/datadog; disable the UDS listeners
+# (TCP 8126 / UDP 8125 are used instead).
+export DD_APM_RECEIVER_SOCKET=""
+export DD_DOGSTATSD_SOCKET=""


### PR DESCRIPTION
Every `git push heroku` build, release phase run, and `heroku run bash` session currently emits Datadog noise. The datadog gem prints startup INFO lines and a `Failed to convert tag: tag 'version:' ends with a colon` WARN twice per boot because the buildpack exports `DD_TAGS` with an empty `version:` tag. Build-time `rake assets:precompile` logs `Errno::ECONNREFUSED` errors because no agent runs during builds. The agent itself logs two UDS listener ERROR lines on every dyno start because `/var/run/datadog` cannot be created in a dyno, and about 480 such errors per day are ingested as Datadog logs.

This sets `DD_TRACE_STARTUP_LOGS=false` and sanitizes the buildpack-provided `DD_TAGS` in `config/boot.rb`, disables tracing, profiling, and runtime metrics for rake processes in the Datadog initializer, and adds `datadog/prerun.sh` to disable the agent UDS listeners. The buildpack sources that file right before starting the agent, and TCP 8126 / UDP 8125 remain in use. Telemetry from web, worker, and scheduler dynos is unaffected. `DISABLE_DATADOG_AGENT` is intentionally not used because one-off dynos need a running agent to keep consoles free of `ECONNREFUSED` noise from the gem.

After merge and deploy, the build output and release phase should be free of datadog lines, `heroku run bash -a bugs-ruby-lang` should print no agent errors, and the Datadog logs query `service:bugs-ruby-lang "UDS listener"` on ap1.datadoghq.com should stop accruing new events.

Generated with [Claude Code](https://claude.com/claude-code)
