### PR TITLE
Skip pg/redis instrumentation in rake processes

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,17 +2,20 @@ require 'pg'
 require 'datadog'
 
 Datadog.configure do |c|
-  c.profiling.enabled = true
-  c.runtime_metrics.enabled = true
   c.version = ENV['HEROKU_RELEASE_VERSION']
-  c.tracing.instrument :pg, comment_propagation: 'full'
-  c.tracing.instrument :redis
 
   # Build-time rake tasks (assets:precompile, assets:clean) run without an
   # agent, so emitting traces only produces ECONNREFUSED errors in build logs.
+  # Instrumenting pg with comment_propagation 'full' would also WARN on every
+  # query once tracing is disabled, so rake keeps the auto_instrument defaults.
   if File.basename($PROGRAM_NAME) == 'rake'
     c.tracing.enabled = false
     c.profiling.enabled = false
     c.runtime_metrics.enabled = false
+  else
+    c.profiling.enabled = true
+    c.runtime_metrics.enabled = true
+    c.tracing.instrument :pg, comment_propagation: 'full'
+    c.tracing.instrument :redis
   end
 end


### PR DESCRIPTION
#219 disabled tracing for rake processes but left the `c.tracing.instrument :pg, comment_propagation: 'full'` call in place. The datadog gem logs `WARN -- datadog: Sql comment propagation with 'full' mode is aborted, because tracing is disabled.` from `SqlComment.prepend_comment` for every query it sees in full mode while tracing is off, so the release phase output filled with these lines.

Rake processes now skip the `pg` and `redis` `instrument` calls entirely. With `datadog/auto_instrument` in `Gemfile.local` the pg integration stays patched with its default `comment_propagation` of `disabled`, which returns the SQL unchanged before reaching the warning path. Non-rake processes keep full comment propagation, profiling, and runtime metrics as before.

Verified locally against datadog 2.36.0. With `$PROGRAM_NAME` set to `rake` the propagation mode resolves to `disabled` and `prepend_comment` emits nothing, and with a non-rake program name it resolves to `full` with tracing enabled.

Generated with [Claude Code](https://claude.com/claude-code)
