### PR TITLE
Disable Datadog emission in agent-less environments

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -13,6 +13,13 @@ if ENV['DD_TAGS']
   ENV['DD_TAGS'] = ENV['DD_TAGS'].split(/[\s,]+/).reject { |t| t.end_with?(':') }.join(',')
 end
 
+# The build environment and local development have no Datadog agent. DYNO is
+# only set in Heroku runtime dynos, where the buildpack starts one. Tracing
+# must be off from process start because spans created while Rails boots
+# would already be flushed to 127.0.0.1:8126 before initializers could
+# disable it.
+ENV['DD_TRACE_ENABLED'] ||= 'false' unless ENV['DYNO']
+
 # Rack 3.1.14 or later sets default limits of 4MB for query string bytesize
 # and 4096 for the number of query parameters. These limits are too low
 # for Redmine and can cause the following issues:

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -5,13 +5,18 @@
 # rather than in config/initializers/datadog.rb.
 ENV['DD_TRACE_STARTUP_LOGS'] ||= 'false'
 
-# The Datadog Heroku buildpack exports DD_TAGS containing an empty "version:"
-# tag (DD_VERSION is unset; the version is set in config/initializers/datadog.rb
-# instead), which the datadog gem rejects with a WARN twice per boot. Drop
-# malformed tags before the gem parses them.
+# Defensively drop tags with an empty value from DD_TAGS before the gem
+# parses it. libdatadog rejects tags that end with a colon.
 if ENV['DD_TAGS']
   ENV['DD_TAGS'] = ENV['DD_TAGS'].split(/[\s,]+/).reject { |t| t.end_with?(':') }.join(',')
 end
+
+# The Datadog buildpack unconditionally re-exports DD_VERSION, so an unset
+# value reaches the app as an empty string. The gem then builds a "version:"
+# tag that libdatadog rejects with a WARN twice per boot. datadog/prerun.sh
+# sets the real version in dynos, and this covers any environment where the
+# variable is still empty.
+ENV.delete('DD_VERSION') if ENV['DD_VERSION'] == ''
 
 # The build environment and local development have no Datadog agent. DYNO is
 # only set in Heroku runtime dynos, where the buildpack starts one. Tracing

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -4,11 +4,15 @@ require 'datadog'
 Datadog.configure do |c|
   c.version = ENV['HEROKU_RELEASE_VERSION']
 
-  # Build-time rake tasks (assets:precompile, assets:clean) run without an
-  # agent, so emitting traces only produces ECONNREFUSED errors in build logs.
-  # Instrumenting pg with comment_propagation 'full' would also WARN on every
-  # query once tracing is disabled, so rake keeps the auto_instrument defaults.
-  if File.basename($PROGRAM_NAME) == 'rake'
+  # Processes without an agent must not emit telemetry or the datadog gem
+  # logs ECONNREFUSED. The build environment (assets:precompile and the
+  # buildpack's "rails runner" config detection) never has an agent and is
+  # recognizable by the absence of DYNO, which is also absent in local
+  # development. Rake stays silent in runtime dynos too because release-phase
+  # migration traces are not useful. Skipping the pg/redis instrumentation
+  # keeps comment_propagation at the auto_instrument default, since 'full'
+  # WARNs on every query while tracing is disabled.
+  if ENV['DYNO'].nil? || File.basename($PROGRAM_NAME) == 'rake'
     c.tracing.enabled = false
     c.profiling.enabled = false
     c.runtime_metrics.enabled = false

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,9 +1,10 @@
 require 'pg'
 require 'datadog'
 
+# The version tag comes from DD_VERSION, set in datadog/prerun.sh. Setting it
+# here would be too late for the crashtracker, which starts before
+# initializers run.
 Datadog.configure do |c|
-  c.version = ENV['HEROKU_RELEASE_VERSION']
-
   # Processes without an agent must not emit telemetry or the datadog gem
   # logs ECONNREFUSED. The build environment (assets:precompile and the
   # buildpack's "rails runner" config detection) never has an agent and is

--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -4,3 +4,10 @@
 # (TCP 8126 / UDP 8125 are used instead).
 export DD_APM_RECEIVER_SOCKET=""
 export DD_DOGSTATSD_SOCKET=""
+
+# The buildpack unconditionally re-exports DD_VERSION after sourcing this
+# file, turning an unset value into an empty string. The datadog gem then
+# builds a "version:" tag that libdatadog rejects with a WARN twice per boot.
+# Set the real release version here so unified service tagging works from
+# process start.
+export DD_VERSION="${DD_VERSION:-$HEROKU_RELEASE_VERSION}"


### PR DESCRIPTION
The build still logs Datadog errors after #220 because the Ruby buildpack's "Detecting rails configuration" step boots Rails through `rails runner`, whose `$PROGRAM_NAME` never matches the rake guard. That process enabled tracing and profiling with no agent available, and with `datadog/auto_instrument` Redmine's boot queries create spans that can flush to `127.0.0.1:8126` even before initializers run, so guarding inside `Datadog.configure` alone cannot be fully quiet.

`DYNO` is set in every Heroku runtime dyno, where the buildpack starts an agent, and absent exactly where none runs, namely the build environment and local development. `config/boot.rb` now sets `DD_TRACE_ENABLED=false` when `DYNO` is absent so the tracer is off from gem load, and the initializer guard keys off the same condition to keep profiling and runtime metrics disabled and to skip the pg/redis instrumentation. The rake condition stays so release-phase migrations remain silent. Web, worker, and one-off dynos are unaffected.

The second commit fixes the `Failed to convert tag: tag 'version:' ends with a colon` WARN that survived into the release phase. The root cause is not `DD_TAGS` but the buildpack's unconditional `export DD_VERSION="$DD_VERSION"`, which turns an unset `DD_VERSION` into an empty string. The gem then reports `settings.version` as `""` and the crashtracker (libdatadog) rejects the resulting `version:` tag, twice per boot because the crashtracker starts at gem load and again on `Datadog.configure`. That first start is also why `c.version` in the initializer could not help, so `datadog/prerun.sh` now exports `DD_VERSION` from `HEROKU_RELEASE_VERSION` before the buildpack's re-export, `config/boot.rb` defensively deletes an empty `DD_VERSION`, and the initializer line is removed. As a bonus the version tag is now correct from process start, including spans emitted while Rails boots.

Verified locally against datadog 2.36.0. `DD_VERSION=""` reproduces the WARN twice per boot while unset or non-empty values are silent, without `DYNO` the tracer reports disabled before `Datadog.configure` runs, and with `DYNO=web.1` under a non-rake program name tracing stays enabled with `comment_propagation` `full`.

Generated with [Claude Code](https://claude.com/claude-code)
