### PR TITLE
Detect agent presence via DD_HEROKU_DYNO instead of DYNO

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -18,12 +18,13 @@ end
 # variable is still empty.
 ENV.delete('DD_VERSION') if ENV['DD_VERSION'] == ''
 
-# The build environment and local development have no Datadog agent. DYNO is
-# only set in Heroku runtime dynos, where the buildpack starts one. Tracing
-# must be off from process start because spans created while Rails boots
-# would already be flushed to 127.0.0.1:8126 before initializers could
-# disable it.
-ENV['DD_TRACE_ENABLED'] ||= 'false' unless ENV['DYNO']
+# The build environment and local development have no Datadog agent. DYNO
+# cannot distinguish them because Heroku sets it in build dynos too. The
+# buildpack's .profile.d script exports DD_HEROKU_DYNO=true, runs only where
+# it starts an agent, and never runs at build time. Tracing must be off from
+# process start because spans created while Rails boots would already be
+# flushed to 127.0.0.1:8126 before initializers could disable it.
+ENV['DD_TRACE_ENABLED'] ||= 'false' unless ENV['DD_HEROKU_DYNO']
 
 # Rack 3.1.14 or later sets default limits of 4MB for query string bytesize
 # and 4096 for the number of query parameters. These limits are too low

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -7,13 +7,15 @@ require 'datadog'
 Datadog.configure do |c|
   # Processes without an agent must not emit telemetry or the datadog gem
   # logs ECONNREFUSED. The build environment (assets:precompile and the
-  # buildpack's "rails runner" config detection) never has an agent and is
-  # recognizable by the absence of DYNO, which is also absent in local
-  # development. Rake stays silent in runtime dynos too because release-phase
+  # buildpack's "rails runner" config detection) never has an agent, and DYNO
+  # cannot recognize it because Heroku sets DYNO in build dynos too. Instead
+  # key off DD_HEROKU_DYNO, which the buildpack's .profile.d script exports
+  # exactly where it starts an agent (never at build, never in local
+  # development). Rake stays silent in runtime dynos too because release-phase
   # migration traces are not useful. Skipping the pg/redis instrumentation
   # keeps comment_propagation at the auto_instrument default, since 'full'
   # WARNs on every query while tracing is disabled.
-  if ENV['DYNO'].nil? || File.basename($PROGRAM_NAME) == 'rake'
+  if ENV['DD_HEROKU_DYNO'].nil? || File.basename($PROGRAM_NAME) == 'rake'
     c.tracing.enabled = false
     c.profiling.enabled = false
     c.runtime_metrics.enabled = false


### PR DESCRIPTION
The build-time agent errors survived #221 because its guard tested for the absence of `DYNO`, and Heroku sets `DYNO` in build dynos too, so the buildpack's "Detecting rails configuration" `rails runner` process still booted with tracing and profiling enabled. The failure is only visible on staging because `HEROKU_DEBUG_RAILS_RUNNER` is set there, which makes the Ruby buildpack echo the runner command and its output. Production runs the same step with the same errors but the buildpack swallows the output without that flag.

The reliable marker for an agent-carrying environment is `DD_HEROKU_DYNO=true`, which the Datadog buildpack's `.profile.d` script exports unconditionally right before starting the agent. That script runs in every runtime dyno including release and one-off dynos and never runs at build time or in local development, so both the `DD_TRACE_ENABLED` guard in `config/boot.rb` and the emission guard in the initializer now key off it.

Verified locally against datadog 2.36.0 that with `DYNO=build.1234` and no `DD_HEROKU_DYNO` both tracing and profiling end up disabled, and that with `DD_HEROKU_DYNO=true` under a non-rake program name tracing stays enabled with `comment_propagation` `full`.

Generated with [Claude Code](https://claude.com/claude-code)
