### PR TITLE
Allow issue CSV and PDF export for logged-in users

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -72,10 +72,21 @@ class IssuesController < ApplicationController
                       :title => "#{@project || Setting.app_title}: #{l(:label_issue_plural)}")
         end
         format.csv do
-          render_403
+          if User.current.logged?
+            issues = @query.issues(:limit => Setting.issues_export_limit.to_i)
+            send_data(query_to_csv(issues, @query, params[:csv]),
+                      :type => 'text/csv; header=present', :filename => "#{filename_for_export(@query, 'issues')}.csv")
+          else
+            render_403
+          end
         end
         format.pdf do
-          render_403
+          if User.current.logged?
+            @issues = @query.issues(:limit => Setting.issues_export_limit.to_i)
+            send_file_headers! :type => 'application/pdf', :filename => "#{filename_for_export(@query, 'issues')}.pdf"
+          else
+            render_403
+          end
         end
       end
     else
@@ -132,9 +143,12 @@ class IssuesController < ApplicationController
         :content_type => 'application/atom+xml'
       end
       format.pdf do
-        render_403
-        #send_file_headers!(:type => 'application/pdf',
-        #                   :filename => "#{@project.identifier}-#{@issue.id}.pdf")
+        if User.current.logged?
+          send_file_headers!(:type => 'application/pdf',
+                             :filename => "#{@project.identifier}-#{@issue.id}.pdf")
+        else
+          render_403
+        end
       end
     end
   end


### PR DESCRIPTION
Datadog shows that every request blocked by the blanket CSV/PDF export 403 introduced in 246098b9f carries a stale bot user agent and none of them are authenticated, while the block also took the export feature away from committers. This restores the original `send_data` and `send_file_headers!` behavior on the issues index and issue detail for logged-in users and keeps responding 403 to anonymous requests.

Generated with [Claude Code](https://claude.com/claude-code)
