### PR TITLE
Point agent UDS listeners at a writable directory

### DIFF
--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Sourced by the Datadog Heroku buildpack before starting the agent.
-# Dynos cannot create /var/run/datadog; disable the UDS listeners
-# (TCP 8126 / UDP 8125 are used instead).
-export DD_APM_RECEIVER_SOCKET=""
-export DD_DOGSTATSD_SOCKET=""
+# Dynos cannot create the default socket directory /var/run/datadog, and the
+# agent ignores empty values for these settings, so the listeners cannot be
+# disabled. Point them at a writable directory instead so they start cleanly.
+# The app talks to the agent over TCP 8126 / UDP 8125 either way.
+mkdir -p /tmp/datadog
+export DD_APM_RECEIVER_SOCKET="/tmp/datadog/apm.socket"
+export DD_DOGSTATSD_SOCKET="/tmp/datadog/dsd.socket"
 
 # The buildpack unconditionally re-exports DD_VERSION after sourcing this
 # file, turning an unset value into an empty string. The datadog gem then


### PR DESCRIPTION
Every agent start still logs `Could not start UDS listener: socket directory does not exist: /var/run/datadog/apm.socket` and `Can't init UDS listener on path /var/run/datadog/dsd.socket`, roughly every 10 minutes on production because one-off dynos start their own agent. #219 tried to disable the listeners by exporting empty `DD_APM_RECEIVER_SOCKET` and `DD_DOGSTATSD_SOCKET` from `datadog/prerun.sh`, but the agent treats an empty environment value as unset and falls back to the `/var/run/datadog` defaults, which a dyno cannot create. The `DD_VERSION` export in the same file demonstrably works, so the script is sourced and the empty values are simply ignored.

Since the listeners cannot be disabled this way, bind them somewhere writable instead. `prerun.sh` now creates `/tmp/datadog` and points both sockets there, so the listeners start cleanly and the errors disappear. The app keeps talking to the agent over TCP 8126 and UDP 8125 as before, and each dyno has its own filesystem so there are no stale socket files.

After deploy, the Datadog logs query `service:bugs-ruby-lang "UDS listener"` should stop accruing new events.

Generated with [Claude Code](https://claude.com/claude-code)
