### PR TITLE
Drop nonexistent heads from git log excludes

### DIFF
--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -145,6 +145,11 @@ class Repository::Git < Repository
     prev_db_heads += heads_from_branches_hash if prev_db_heads.empty?
     return if prev_db_heads.sort == repo_heads.sort
 
+    # A recorded head no longer exists when the branch was force-pushed
+    # or deleted upstream. Passing it to "git log --not" aborts with
+    # "fatal: bad object", so drop such heads before the scan.
+    prev_db_heads.select! {|head| scm.valid_rev?(head)}
+
     h["db_consistent"]  ||= {}
     if ! changesets.exists?
       h["db_consistent"]["ordering"] = 1

--- a/lib/redmine/scm/adapters/git_adapter.rb
+++ b/lib/redmine/scm/adapters/git_adapter.rb
@@ -107,6 +107,17 @@ module Redmine
           nil
         end
 
+        # Returns true if the revision exists as a commit in the repository
+        def valid_rev?(rev)
+          return false unless /\A[0-9a-f]{7,40}\z/.match?(rev.to_s)
+
+          cmd_args = %w|cat-file -e| << "#{rev}^{commit}"
+          git_cmd(cmd_args) {|io| io.read}
+          true
+        rescue ScmCommandAborted
+          false
+        end
+
         def default_branch
           return if branches.blank?
 

--- a/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/git_adapter_test.rb
@@ -69,6 +69,14 @@ class GitAdapterTest < ActiveSupport::TestCase
       end
     end
 
+    def test_valid_rev
+      assert_equal true,  @adapter.valid_rev?('2a682156a3b6e77a8bf9cd4590e8db757f3c6c78')
+      assert_equal true,  @adapter.valid_rev?('2a682156')
+      assert_equal false, @adapter.valid_rev?('79d56a81f880bb96aa6c10afecd57472776aa60b')
+      assert_equal false, @adapter.valid_rev?('master')
+      assert_equal false, @adapter.valid_rev?(nil)
+    end
+
     def test_branches
       brs = @adapter.branches
       assert_equal 8, brs.length

--- a/test/unit/repository_git_test.rb
+++ b/test/unit/repository_git_test.rb
@@ -236,11 +236,15 @@ class RepositoryGitTest < ActiveSupport::TestCase
       assert h1.index("1234abcd5678")
       assert_equal NUM_HEAD - 1, h1.size
 
+      # The invalid head is dropped, the missing revisions are scanned
+      # again from the current heads, and the heads are updated.
       @repository.fetch_changesets
       @project.reload
-      assert_equal NUM_REV - del_revs.size + 1, @repository.changesets.count
+      assert_equal NUM_REV + 1, @repository.changesets.count
       h2 = @repository.extra_info["heads"].dup
-      assert_equal h1, h2
+      assert_equal NUM_HEAD, h2.size
+      assert h2.index("b1650eac7c505a6dab9f19858afc9ecb481eccc2")
+      assert_nil h2.index("1234abcd5678")
     end
 
     def test_clear_changesets_should_keep_report_last_commit


### PR DESCRIPTION
`Repository.fetch_changesets` on production stopped updating with `fatal: bad object 79d56a81...` after the `ruby_4_0` branch was force-pushed during the 4.0.6 release redo. The head recorded in `extra_info["heads"]` no longer exists in a freshly cloned mirror, and every recorded head is passed to `git log` as `^sha`, so the scan aborts on every run and never recovers. This adds `GitAdapter#valid_rev?` backed by `git cat-file -e` and drops unresolvable heads before the scan, so stale heads are discarded automatically and the missing revisions are picked up from the current heads. `test_fetch_changesets_history_editing` encoded the old silent-abort behavior and is updated to the new semantics.

Generated with [Claude Code](https://claude.com/claude-code)
