### PR TITLE
Silence recurring Datadog agent ERROR logs on dynos

### DIFF
--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -14,3 +14,12 @@ export DD_DOGSTATSD_SOCKET="/tmp/datadog/dsd.socket"
 # Set the real release version here so unified service tagging works from
 # process start.
 export DD_VERSION="${DD_VERSION:-$HEROKU_RELEASE_VERSION}"
+
+# The postgres integration enables DBM schema collection by default, but the
+# collector never obtains a pool connection on Heroku Postgres and logs a
+# PoolTimeout ERROR every 600s without ever collecting any schema data.
+# The buildpack generates the postgres config before sourcing this file,
+# so append the override under the generated instance.
+if [ -n "$POSTGRES_CONF" ] && [ -f "$POSTGRES_CONF/conf.yaml" ]; then
+  printf '    collect_schemas:\n      enabled: false\n' >> "$POSTGRES_CONF/conf.yaml"
+fi

--- a/datadog/prerun.sh
+++ b/datadog/prerun.sh
@@ -15,6 +15,11 @@ export DD_DOGSTATSD_SOCKET="/tmp/datadog/dsd.socket"
 # process start.
 export DD_VERSION="${DD_VERSION:-$HEROKU_RELEASE_VERSION}"
 
+# Agent 7.80 defaults discovery.enabled to true on Linux, making the
+# workloadmeta process collector poll system-probe every 60s. system-probe
+# cannot run on dynos, so every poll logs an ERROR.
+export DD_DISCOVERY_ENABLED=false
+
 # The postgres integration enables DBM schema collection by default, but the
 # collector never obtains a pool connection on Heroku Postgres and logs a
 # PoolTimeout ERROR every 600s without ever collecting any schema data.


### PR DESCRIPTION
The agent logs two recurring ERROR tracebacks on every dyno, visible in one-off dyno consoles and ingested through the log drain. First, the postgres integration defaults `collect_schemas.enabled` to true, which activates with the buildpack's `dbm: true`. The schema collector times out waiting for a pool connection on every 600s run and has never collected any schema data, so `datadog/prerun.sh` now appends `collect_schemas: enabled: false` to the generated postgres config. Second, agent 7.80 defaults `discovery.enabled` to true on Linux, making the workloadmeta process collector poll the system-probe socket every 60s. system-probe cannot run on dynos, so `prerun.sh` exports `DD_DISCOVERY_ENABLED=false`. Same family as DataDog/heroku-buildpack-datadog#432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
