### PR TITLE
Redirect anonymous revision views to GitHub

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/init.rb
+++ b/plugins/redmine_bugs_ruby_lang/init.rb
@@ -77,6 +77,7 @@ require 'redmine_ruby_lang_mailing_list_customization/redmine_ext'
 
 require 'redmine_bugs_ruby_lang/anonymous_filter/issues_controller'
 require 'redmine_bugs_ruby_lang/anonymous_filter/activities_controller'
+require 'redmine_bugs_ruby_lang/anonymous_filter/repositories_controller'
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular 'use_of_mailng_list', 'uses_of_mailing_list'

--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/repositories_controller.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/anonymous_filter/repositories_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RedmineBugsRubyLang
+  module AnonymousFilter
+    module RepositoriesController
+      GITHUB_COMMIT_URL = "https://github.com/ruby/ruby/commit/"
+
+      private
+
+      def redirect_anonymous_revision_to_github
+        return if User.current.logged?
+        return unless @project&.identifier == "ruby-master"
+
+        redirect_to "#{GITHUB_COMMIT_URL}#{@changeset.revision}",
+          :status => :moved_permanently, :allow_other_host => true
+      end
+    end
+  end
+end
+
+RepositoriesController.class_eval do
+  prepend RedmineBugsRubyLang::AnonymousFilter::RepositoriesController
+
+  before_action :redirect_anonymous_revision_to_github, :only => :revision
+end


### PR DESCRIPTION
A Lightpanda/1.0 crawler has been hammering `RepositoriesController#revision` since 2026-07-25, peaking at 70k requests over two days. Each render averages 2.5s, so the crawler alone held several Puma workers and pushed queue waits past the 30s `Rack::Timeout` limit, returning 500s to regular users as well. Guests requesting a revision on the ruby-master project now get a permanent redirect to the matching commit on `github.com/ruby/ruby`, while logged-in users keep the local view. The guard lives in the `redmine_bugs_ruby_lang` plugin next to the existing anonymous filters and is scoped to ruby-master so upstream functional tests, which exercise anonymous revision access on fixture projects, keep passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
