### PR TITLE
Keep archived project issues readable by permalink

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/init.rb
+++ b/plugins/redmine_bugs_ruby_lang/init.rb
@@ -78,6 +78,8 @@ require 'redmine_ruby_lang_mailing_list_customization/redmine_ext'
 require 'redmine_bugs_ruby_lang/anonymous_filter/issues_controller'
 require 'redmine_bugs_ruby_lang/anonymous_filter/activities_controller'
 require 'redmine_bugs_ruby_lang/anonymous_filter/repositories_controller'
+require 'redmine_bugs_ruby_lang/archived_permalink/project'
+require 'redmine_bugs_ruby_lang/archived_permalink/user'
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular 'use_of_mailng_list', 'uses_of_mailing_list'

--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/archived_permalink/project.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/archived_permalink/project.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RedmineBugsRubyLang
+  module ArchivedPermalink
+    module Project
+      # Archived projects stay out of every SQL visibility scope, so nothing
+      # links to their issues. Reading one by permalink is still allowed here.
+      READABLE_ACTIONS = %w[issues/show issues/issue_tab].freeze
+
+      def allows_to?(action)
+        return super unless archived?
+
+        if action.is_a?(Hash)
+          name = "#{action[:controller]}/#{action[:action]}"
+          READABLE_ACTIONS.include?(name) && allowed_actions.include?(name)
+        else
+          action == :view_issues && allowed_permissions.include?(action)
+        end
+      end
+    end
+  end
+end
+
+Project.class_eval do
+  prepend RedmineBugsRubyLang::ArchivedPermalink::Project
+end

--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/archived_permalink/user.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_bugs_ruby_lang/archived_permalink/user.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RedmineBugsRubyLang
+  module ArchivedPermalink
+    module User
+      # Redmine grants no role at all on an archived project, which would deny
+      # the read that Project#allows_to? lets through. Actions stay gated there.
+      def roles_for_project(project)
+        return super unless project&.archived?
+
+        if (membership = membership(project))
+          membership.roles.to_a
+        elsif project.is_public?
+          project.override_roles(builtin_role)
+        else
+          []
+        end
+      end
+    end
+  end
+end
+
+User.class_eval do
+  prepend RedmineBugsRubyLang::ArchivedPermalink::User
+end

--- a/plugins/redmine_bugs_ruby_lang/test/integration/archived_permalink_test.rb
+++ b/plugins/redmine_bugs_ruby_lang/test/integration/archived_permalink_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+
+class ArchivedPermalinkTest < Redmine::IntegrationTest
+  def setup
+    super
+    Project.find(1).archive
+  end
+
+  def test_anonymous_can_read_an_archived_issue_by_permalink
+    get '/issues/1'
+
+    assert_response :success
+    assert_select 'div.subject h3', :text => 'Cannot print recipes'
+  end
+
+  def test_archived_project_page_stays_denied
+    get '/projects/ecookbook'
+
+    assert_response :forbidden
+  end
+
+  def test_archived_project_issue_list_stays_denied
+    get '/projects/ecookbook/issues'
+
+    assert_response :forbidden
+  end
+
+  def test_archived_issue_is_absent_from_the_global_issue_list
+    get '/issues'
+
+    assert_response :success
+    assert_select 'tr#issue-1', 0
+  end
+
+  def test_archived_issue_is_absent_from_the_visible_scope
+    assert_nil Issue.visible(User.find(1)).find_by_id(1)
+  end
+
+  def test_archived_issue_stays_read_only
+    log_user('jsmith', 'jsmith')
+    get '/issues/1/edit'
+
+    assert_response :forbidden
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1211,11 +1211,13 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  # :view_issues is granted on archived projects here so that old issue
+  # permalinks keep working. See redmine_bugs_ruby_lang's archived_permalink.
   test "#allowed_to? for archived project should return false" do
     project = Project.find(1)
     project.archive
     project.reload
-    assert_equal false, @admin.allowed_to?(:view_issues, project)
+    assert_equal false, @admin.allowed_to?(:edit_issues, project)
   end
 
   test "#allowed_to? for closed project should return true for read actions" do


### PR DESCRIPTION
Archiving the old Backport and Ruby 1.8 projects took roughly 3,000 issues out of every visibility scope, so a permalink like `/issues/449` answers with a login redirect for anonymous visitors and a 403 for everyone else, admins included. The rows are still in the database and the links are still out there in mailing list archives.

Whether an issue appears in a listing is decided by SQL in `Project.allowed_to_condition`, which pins `projects.status IN (1, 5)`. Whether a single page opens is decided in Ruby by `Project#allows_to?` and `User#roles_for_project`. This grants the issue read actions in the Ruby path only, so archived projects stay out of the project list, the cross-project issue list, search and the REST API while permalinks resolve again. `issues/index` is left denied so that no crawlable listing appears, and writes still fall through to the archived branch. No database change is needed and the projects stay archived.

`test/unit/user_test.rb` asserted that `:view_issues` is denied on archived projects, which is the rule this drops, so it now asserts `:edit_issues` and the read case moves to the new plugin test.
