### PR TITLE
Archive only numbered mailing list posts to S3

### DIFF
--- a/plugins/redmine_bugs_ruby_lang/lib/redmine_mailing_list_integration_imap_supplement/imap.rb
+++ b/plugins/redmine_bugs_ruby_lang/lib/redmine_mailing_list_integration_imap_supplement/imap.rb
@@ -81,6 +81,7 @@ module RedmineMailingListIntegrationImapSupplement
       list_name = list_name && list_name[1]
       post_id = m.header["Subject"].to_s.match(/\[#{list_name}:(\d+)\].*/)
       post_id = post_id && post_id[1]
+      return unless list_name && post_id
 
       s3.bucket('blade-data-vault').object("#{list_name}/#{post_id}").put(body: msg)
 
@@ -102,7 +103,7 @@ module RedmineMailingListIntegrationImapSupplement
 
       s3.bucket('blade.ruby-lang.org').object("#{list_name}/#{post_id}").put(body: io.string)
     ensure
-      io.close
+      io&.close
     end
 
     def logger

--- a/plugins/redmine_bugs_ruby_lang/test/unit/imap_supplement_test.rb
+++ b/plugins/redmine_bugs_ruby_lang/test/unit/imap_supplement_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+
+class ImapSupplementTest < ActiveSupport::TestCase
+  def setup
+    @s3 = Aws::S3::Resource.new(stub_responses: true)
+    Aws::S3::Resource.stubs(:new).returns(@s3)
+  end
+
+  def test_list_post_is_archived_in_both_buckets
+    record_s3(<<~MAIL)
+      List-Id: <ruby-core.ml.ruby-lang.org>
+      Subject: [ruby-core:123456] [Ruby Feature#1] Hello
+
+      body
+    MAIL
+
+    assert_equal [['blade-data-vault', 'ruby-core/123456'], ['blade.ruby-lang.org', 'ruby-core/123456']], archived_keys
+  end
+
+  def test_mail_outside_mailing_lists_is_not_archived
+    record_s3(<<~MAIL)
+      Subject: Security alert
+
+      body
+    MAIL
+
+    assert_empty archived_keys
+  end
+
+  def test_list_notice_without_post_number_is_not_archived
+    record_s3(<<~MAIL)
+      List-Id: <ruby-core.ml.ruby-lang.org>
+      Subject: Your message to ruby-core awaits moderator approval
+
+      body
+    MAIL
+
+    assert_empty archived_keys
+  end
+
+  private
+
+  def record_s3(msg)
+    RedmineMailingListIntegrationImapSupplement::IMAP.record_s3(msg)
+  end
+
+  def archived_keys
+    @s3.client.api_requests.map {|req| req[:params].values_at(:bucket, :key)}
+  end
+end


### PR DESCRIPTION
`IMAP.receive` passes every fetched mail to `record_s3`, which wrote it to `blade-data-vault` and `blade.ruby-lang.org` under `"#{list_name}/#{post_id}"` even when either part was missing. A Google security alert ended up at `/`, and mailman moderation requests at `ruby-core/` and `ruby-dev/`. The public bucket serves archive.ruby-lang.org, so those notices were readable there, and each new one overwrote the same key.

`record_s3` now skips mail unless both the list name and the post number are found. Regular list posts still go to both buckets under `<list>/<number>`, and `MailHandler.receive` still handles every mail as before. The new unit test stubs S3 and covers a list post, a non-list mail, and a moderation notice.

Generated with [Claude Code](https://claude.com/claude-code)
